### PR TITLE
Improve map location following

### DIFF
--- a/frontend/src/Main.tsx
+++ b/frontend/src/Main.tsx
@@ -1,28 +1,13 @@
 import { StyleSheet, View } from 'react-native'
 import { Map } from './components/Map'
-import { useState, useEffect } from 'react'
-import { type Coordinate, subscribeUserLocation } from './services/location'
 
 /**
  * The main screen containing the map and bottom sheet pattern.
  */
 export function Main(): React.ReactElement<void> {
-  const [location, setLocation] = useState<Coordinate | null>(null)
-
-  useEffect(() => {
-    const promise = subscribeUserLocation(setLocation)
-    // Clean up memory once component unmounts
-    return () => {
-      promise
-        .then((watcher) => { watcher.remove() })
-        .catch(console.error)
-    }
-  }, [])
-
   return (
     <View>
-      <Map style={StyleSheet.absoluteFillObject}
-        currentLocation={location} />
+      <Map style={StyleSheet.absoluteFillObject} />
     </View>
   )
 }

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -1,7 +1,7 @@
 import MapView, { type Region } from 'react-native-maps'
 import { StyleSheet, type ViewProps, Platform } from 'react-native'
 import { type Coordinate } from '../services/location'
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 
 
 const GOLDEN: Region = {
@@ -15,12 +15,13 @@ const GOLDEN: Region = {
  * Wraps the expo {@interface MapView} with additional functionality.
  */
 export function Map(props: ViewProps): React.ReactElement<ViewProps> {
+  const [userRegionChanged, setUserRegionChanged] = useState(false)
   const mapRef = useRef<MapView>(null)
 
   function followUserLocationAndroid(location: Coordinate | undefined): void {
     // We want to make sure we won't snap back to the user location if they decide to pan around,
     // so check if that's the case before panning.
-    if (location !== undefined && mapRef.current != null)  {
+    if (location !== undefined && mapRef.current != null && !userRegionChanged)  {
       mapRef.current.animateCamera({
         center: location,
         zoom: 17
@@ -33,11 +34,12 @@ export function Map(props: ViewProps): React.ReactElement<ViewProps> {
       ref={mapRef}
       initialRegion={GOLDEN}
       showsUserLocation={true}
+      onRegionChange={() => { setUserRegionChanged(true) }}
       // Android only.
       showsMyLocationButton={false}
       // followsUserLocation is only available on iOS, so we must reimplement the behavior on Android
       // with onUserLocationChange.
-      followsUserLocation={true}
+      followsUserLocation={!userRegionChanged}
       onUserLocationChange={Platform.select({ 
         android: event => { followUserLocationAndroid(event.nativeEvent.coordinate) } 
       })} />

--- a/frontend/src/services/location.ts
+++ b/frontend/src/services/location.ts
@@ -1,5 +1,8 @@
 import * as Location from 'expo-location'
 
+// NOTE: This is not currently used, but will be in the future so that other components can have location
+// access without hoisting the map location state.
+
 /**
  * Implemenetation of latitude/longitude-based coordinates independent from any particular
  * mapping library.
@@ -28,8 +31,8 @@ export async function subscribeUserLocation(cb: LocationCallback): Promise<Locat
     cb(null)
   }
 
-  // Component need the ability to remove their location subscription once unmounted, which requires access
-  // to the handle object Expo returns, hence why we return it.
+  // Component needs the ability to remove their location subscription once unmounted, which requires access
+  // the subscription object.
   return await Location.watchPositionAsync(
     { accuracy: ACCURACY },
     newLocation => { cb(newLocation.coords) }


### PR DESCRIPTION
- Use native location following APIs instead of the prior janky system
- Do not snap to location if the user is panning around.

Resolves #10.