### PR TITLE
Change workflows to only run checks on pushes/prs to main

### DIFF
--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -1,6 +1,7 @@
 name: Lint-Node
 
 on: [push, pull_request]
+  branches: [main]
 
 jobs:
   lint-node:

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -1,6 +1,7 @@
 name: Lint-Python
 
 on: [push, pull_request]
+  branches: [main]
 
 jobs:
   lint-python:


### PR DESCRIPTION
I noticed that PR checks ran twice, since it was checking for the push and the PR.

![image](https://github.com/OreCart/OreCart-App/assets/9543284/cc85c65a-feb5-4cfe-bbc1-cd4c0e896593)

As such, I added a filter to the workflows that restricts runs to only pushes and PRs to `main`.
We can do something else if we wish, but I feel like checks on pushes aren't really helpful.