### PR TITLE
Rework frontend API spec

### DIFF
--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -51,7 +51,7 @@ interface Location {
   vanId: number;
   routeId: number;
   location: Coordinate;
-  timestampMillis: number;
+  timestamp: Date;
 }
 ```
 
@@ -71,8 +71,8 @@ interface Dashboard {
 
 interface Alert {
   body: string;
-  startTimestampSecs: number;
-  endTimestampSecs: number;
+  startTimestamp: Date;
+  endTimestamp: Date;
 }
 
 interface Route {
@@ -102,7 +102,7 @@ POST `/request`
 ```typescript
 interface Request {
   location: Coordinate;
-  timestampSecs: number;
+  timestamp: Date;
 }
 ```
 
@@ -125,8 +125,8 @@ type Outages = Outage[];
 interface Outage {
   id: number;
   body: string;
-  startTimestampSecs: number;
-  endTimestampSecs: number;
+  startTimestamp: Date;
+  endTimestamp: Date;
   routesDisabled: number[]; // Route ID list
   stopsDisabled: number[]; // Stop ID list
 }
@@ -147,8 +147,8 @@ POST `/admin/outages/`
 ```typescript
 interface Outage {
   body: string;
-  startTimestampSecs: number;
-  endTimestampSecs: number;
+  startTimestamp: Date;
+  endTimestamp: Date;
   routesDisabled: number[]; // Route ID list
   stopsDisabled: number[]; // Stop ID list
 }
@@ -197,19 +197,19 @@ type Van = number[]; // Route ID list, empty if not running
 GET `/stats/ridership/{van_id}`
 
 - Gets ridership information from the van with the specified ID
-- This is likely an expensive calculation, hence why it's in it's own route
+- This is likely an expensive calculation, hence why it's in its own route
 - Message authentication header is a bearer token with specific permissions
   allowing admin actions
 - Communication is HTTPS only
 - Response body is defined in JSON as per the following typescript spec:
 
 ```typescript
-// NOTE: Not final format, unsure exactly what we should be calculating or whether we want to directly provide each
-// datapoint to stakeholders
+// NOTE: Not final format, unsure exactly what we should be calculating or
+whether we want to directly provide each datapoint to stakeholders
 type Ridership = RidershipLog[];
 
 interface RidershipEntry {
-  timestampMillis: number;
+  timestamp: Date;
   location: Coordinate;
   entered: number;
   exited: number;

--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -45,14 +45,14 @@ GET `/location`
 - Communication can be HTTP or HTTPS, but HTTPS is already being used
 - Response body is defined in JSON as per the following typescript spec:
 
-``typescript
+```typescript
 interface Location {
     vanId: number,
     routeId: number,
     location: Coordinate,
     timestampMillis: number
 }
-``
+```
 
 GET `/dashboard`
 

--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -69,7 +69,7 @@ interface Route {
     id: number,
     name: string,
     active: boolean,
-    waypoints: Coordinate[] // Implicitly ordered by index in baackend
+    waypoints: Coordinate[] // Already ordered by index in backend
 }
 
 interface Stop {

--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -53,16 +53,24 @@ interface Location {
 }
 ``
 
-GET `/routes`
+GET `/dashboard`
 
-- Retrieves a predefined list of routes and their waypoints
+- Retrieves all data to show on the main screen of the frontend
 - Coordinates are defined in a config file
+- Alerts with start times in the future or end times in the past are discarded
 - Response body is defined in JSON as per the following typescript spec:
 
 ```typescript
-interface Routes {
+interface Dashboard {
     routes: Route[],
-    stops: Stop[]
+    stops: Stop[],
+    alert: Alert | null
+}
+
+interface Alert {
+    body: string,
+    startTimestampSecs: number,
+    endTimestampSecs: number
 }
 
 interface Route {
@@ -77,20 +85,6 @@ interface Stop {
     name: string,
     active: boolean,
     location: Coordinate
-}
-```
-
-GET `/alert`
-
-- Retrieves the currently active alert that may be disabling a stop or route.
-- Alerts with start times in the future or end times in the past are discarded.
-- Response body is defined in JSON as per the following typescript spec:
-
-```typescript
-interface Alert {
-    body: string,
-    startTimestampSecs: number,
-    endTimestampSecs: number
 }
 ```
 

--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -134,7 +134,7 @@ interface Outage {
 POST `/admin/outages/`
 
 - Schedules a route/stop outage to occur at some point in the future
-- Stops reporting the location of all vans registered to a route
+- Stops reporting the location of all vans registered to a route or stop
 - Requests to a route will override any previous requests
 - Adds message to all status requests
 - Message authentication header is a bearer token with specific permissions

--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -131,7 +131,7 @@ interface Outage {
 }
 ```
 
-POST `/admin/outage/`
+POST `/admin/outages/`
 
 - Schedules a route/stop outage to occur at some point in the future
 - Stops reporting the location of all vans registered to a route
@@ -153,7 +153,7 @@ interface Outage {
 }
 ```
 
-DELETE `/admin/outage/{outage_id}`
+DELETE `/admin/outages/{outage_id}`
 
 - `outage_id` is an 8-bit integer
 - Stops reporting the location of all vans registered to a route

--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -30,7 +30,8 @@ GET `/request/{van_id}`
 
 - `van_id` is an 8-bit integer
 - Subscribes the hardware to SSE for ADA requests
-- Responses are in the format `(lat, lon, timestamp)` where `lat` & `lon` are 64-bit doubles and `timestamp` is a 64-bit unix time value in milliseconds
+- Responses are in the format `(lat, lon, timestamp)` where `lat` & `lon` are
+  64-bit doubles and `timestamp` is a 64-bit UNIX timestamp in milliseconds
 - Message authentication header is a bearer token that is unique per van
 - Communication is HTTPS only
 
@@ -47,10 +48,10 @@ GET `/location`
 
 ```typescript
 interface Location {
-    vanId: number,
-    routeId: number,
-    location: Coordinate,
-    timestampMillis: number
+  vanId: number;
+  routeId: number;
+  location: Coordinate;
+  timestampMillis: number;
 }
 ```
 
@@ -63,29 +64,29 @@ GET `/dashboard`
 
 ```typescript
 interface Dashboard {
-    routes: Route[],
-    stops: Stop[],
-    alert: Alert | null
+  routes: Route[];
+  stops: Stop[];
+  alert: Alert | null;
 }
 
 interface Alert {
-    body: string,
-    startTimestampSecs: number,
-    endTimestampSecs: number
+  body: string;
+  startTimestampSecs: number;
+  endTimestampSecs: number;
 }
 
 interface Route {
-    id: number,
-    name: string,
-    active: boolean,
-    waypoints: Coordinate[] // Already ordered by index in backend
+  id: number;
+  name: string;
+  active: boolean;
+  waypoints: Coordinate[]; // Already ordered by index in backend
 }
 
 interface Stop {
-    id: number,
-    name: string,
-    active: boolean,
-    location: Coordinate
+  id: number;
+  name: string;
+  active: boolean;
+  location: Coordinate;
 }
 ```
 
@@ -100,8 +101,8 @@ POST `/request`
 
 ```typescript
 interface Request {
-    location: Coordinate,
-    timestampSecs: number
+  location: Coordinate;
+  timestampSecs: number;
 }
 ```
 
@@ -119,15 +120,15 @@ GET `/admin/outage`
 - Response body is defined in JSON as per the following typescript spec:
 
 ```typescript
-type Outages = Outage[]
+type Outages = Outage[];
 
 interface Outage {
-    id: number,
-    body: string,
-    startTimestampSecs: number,
-    endTimestampSecs: number,
-    routesDisabled: number[] // Route ID list
-    stopsDisabled: number[] // Stop ID list
+  id: number;
+  body: string;
+  startTimestampSecs: number;
+  endTimestampSecs: number;
+  routesDisabled: number[]; // Route ID list
+  stopsDisabled: number[]; // Stop ID list
 }
 ```
 
@@ -145,11 +146,11 @@ POST `/admin/outages/`
 
 ```typescript
 interface Outage {
-    body: string,
-    startTimestampSecs: number,
-    endTimestampSecs: number,
-    routesDisabled: number[] // Route ID list
-    stopsDisabled: number[] // Stop ID list
+  body: string;
+  startTimestampSecs: number;
+  endTimestampSecs: number;
+  routesDisabled: number[]; // Route ID list
+  stopsDisabled: number[]; // Stop ID list
 }
 ```
 
@@ -165,6 +166,7 @@ DELETE `/admin/outages/{outage_id}`
 ## Vans
 
 GET `/admin/vans`
+
 - Reports current active vans (and assigned route IDs)
 - Message authentication header is a bearer token with specific permissions
   allowing admin actions
@@ -172,15 +174,16 @@ GET `/admin/vans`
 - Response body is defined in JSON as per the following typescript spec:
 
 ```typescript
-type Vans = Van[]
+type Vans = Van[];
 
 interface Van {
-    id: number
-    routes: number[] // Route ID list, empty if not running
+  id: number;
+  routes: number[]; // Route ID list, empty if not running
 }
 ```
 
 POST `/admin/vans/{van_id}`
+
 - Change assigned routes of specified van
 - Message authentication header is a bearer token with specific permissions
   allowing admin actions
@@ -188,10 +191,11 @@ POST `/admin/vans/{van_id}`
 - Request body is defined in JSON as per the following typescript spec:
 
 ```typescript
-type Van = number[] // Route ID list, empty if not running
+type Van = number[]; // Route ID list, empty if not running
 ```
 
 GET `/stats/ridership/{van_id}`
+
 - Gets ridership information from the van with the specified ID
 - This is likely an expensive calculation, hence why it's in it's own route
 - Message authentication header is a bearer token with specific permissions
@@ -202,13 +206,13 @@ GET `/stats/ridership/{van_id}`
 ```typescript
 // NOTE: Not final format, unsure exactly what we should be calculating or whether we want to directly provide each
 // datapoint to stakeholders
-type Ridership = RidershipLog[]
+type Ridership = RidershipLog[];
 
 interface RidershipEntry {
-    timestampMillis: number,
-    location: Coordinate,
-    entered: number,
-    exited: number
+  timestampMillis: number;
+  location: Coordinate;
+  entered: number;
+  exited: number;
 }
 ```
 

--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -66,7 +66,7 @@ GET `/dashboard`
 interface Dashboard {
   routes: Route[];
   stops: Stop[];
-  alert: Alert | null;
+  alert?: Alert;
 }
 
 interface Alert {

--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -87,6 +87,7 @@ interface Stop {
   name: string;
   active: boolean;
   location: Coordinate;
+  routeIds: number[]
 }
 ```
 
@@ -127,8 +128,8 @@ interface Outage {
   body: string;
   startTimestamp: Date;
   endTimestamp: Date;
-  routesDisabled: number[]; // Route ID list
-  stopsDisabled: number[]; // Stop ID list
+  routeIdsDisabled: number[];
+  stopIdsDisabled: number[];
 }
 ```
 
@@ -149,8 +150,8 @@ interface Outage {
   body: string;
   startTimestamp: Date;
   endTimestamp: Date;
-  routesDisabled: number[]; // Route ID list
-  stopsDisabled: number[]; // Stop ID list
+  routeIdsDisabled: number[];
+  stopIdsDisabled: number[];
 }
 ```
 

--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -40,6 +40,7 @@ GET `/location`
 
 - Subscribes the client to SSE triggered by new coordinates to any van
 - Any response with an earlier timestamp than the most recent should be discarded
+- Excessive time drifting will be detected on backend and reported in admin panel
 - Any timestamp more than 1 min in the future should be discarded
 - Communication can be HTTP or HTTPS, but HTTPS is already being used
 - Response body is defined in JSON as per the following typescript spec:

--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -162,27 +162,64 @@ DELETE `/admin/outages/{outage_id}`
   allowing admin actions
 - Communication is HTTPS only
 
+## Vans
+
+GET `/admin/vans`
+- Reports current active vans (and assigned route IDs)
+- Message authentication header is a bearer token with specific permissions
+  allowing admin actions
+- Communication is HTTPS only
+- Response body is defined in JSON as per the following typescript spec:
+
+```typescript
+type Vans = Van[]
+
+interface Van {
+    id: number
+    routes: number[] // Route ID list, empty if not running
+}
+```
+
+POST `/admin/vans/{van_id}`
+- Change assigned routes of specified van
+- Message authentication header is a bearer token with specific permissions
+  allowing admin actions
+- Communication is HTTPS only
+- Request body is defined in JSON as per the following typescript spec:
+
+```typescript
+type Van = number[] // Route ID list, empty if not running
+```
+
+GET `/stats/ridership/{van_id}`
+- Gets ridership information from the van with the specified ID
+- This is likely an expensive calculation, hence why it's in it's own route
+- Message authentication header is a bearer token with specific permissions
+  allowing admin actions
+- Communication is HTTPS only
+- Response body is defined in JSON as per the following typescript spec:
+
+```typescript
+// NOTE: Not final format, unsure exactly what we should be calculating or whether we want to directly provide each
+// datapoint to stakeholders
+type Ridership = RidershipLog[]
+
+interface RidershipEntry {
+    timestampMillis: number,
+    location: Coordinate,
+    entered: number,
+    exited: number
+}
+```
+
 ## Status
 
 GET `/admin/status`
 
 - Reports status + server health info
   - Uptime
-  - Current active vans (and IDs)
   - Current number of clients subscribed
-  - Current ridership figures from each van
 - Response body is serialized JSON w/ an array holding data per van
-- Message authentication header is a bearer token with specific permissions
-  allowing admin actions
-- Communication is HTTPS only
-
-GET `/admin/status/{van_id}`
-
-- Reports detailed van status
-  (is the same as `/admin/status`, but only the specified van)
-  - Is van active?
-  - Current ridership figures from the van
-- Response body is serialized JSON
 - Message authentication header is a bearer token with specific permissions
   allowing admin actions
 - Communication is HTTPS only

--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -6,7 +6,7 @@ POST `/location/{van_id}`
 
 - `van_id` is an 8-bit integer
 - Message body is `(lat, lon, timestamp)`, where `lat` & `lon` are 64-bit doubles,
-  and `timestamp` is a UNIX timestamp
+  and `timestamp` is a UNIX timestamp in milliseconds
   - This minimizes network usage
 - The server should discard any timestamp earlier than the most recent
 - The server should discard any timestamp more than 1 min into the future
@@ -19,7 +19,7 @@ POST `/stats/ridership/{van_id}`
 
 - `van_id` is an 8-bit integer
 - Request body is `(ridership, timestamp)`, where `ridership` is an 8-bit int
-  and `timestamp` is a UNIX timestamp
+  and `timestamp` is a UNIX timestamp in milliseconds
 - The server should discard any timestamp earlier than the most recent
 - The server should discard any timestamp more than 1 min into the future
   (and add admin status message?)
@@ -30,7 +30,7 @@ GET `/request/{van_id}`
 
 - `van_id` is an 8-bit integer
 - Subscribes the hardware to SSE for ADA requests
-- Responses are in the format `(lat, lon)` where `lat` & `lon` are 64-bit doubles
+- Responses are in the format `(lat, lon, timestamp)` where `lat` & `lon` are 64-bit doubles and `timestamp` is a 64-bit unix time value in milliseconds
 - Message authentication header is a bearer token that is unique per van
 - Communication is HTTPS only
 

--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -101,7 +101,7 @@ POST `/request`
 - Any request with a timestamp more than 10 min out-of-date (or in the future)
   should be discarded
 - Communication is HTTPS only
-- Response body is defined in JSON as per the following typescript spec:
+- Request body is defined in JSON as per the following typescript spec:
 
 ```typescript
 interface Request {

--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -44,7 +44,7 @@ GET `/location`
 - Communication can be HTTP or HTTPS, but HTTPS is already being used
 - Response body is defined in JSON as per the following typescript spec:
 
-``ts
+``typescript
 interface Location {
     vanId: number,
     routeId: number,

--- a/backend/backend-schema-proposal.md
+++ b/backend/backend-schema-proposal.md
@@ -89,8 +89,8 @@ GET `/alert`
 ```typescript
 interface Alert {
     body: string,
-    startTimestampMillis: number,
-    endTimestampMillis: number
+    startTimestampSecs: number,
+    endTimestampSecs: number
 }
 ```
 
@@ -106,7 +106,7 @@ POST `/request`
 ```typescript
 interface Request {
     location: Coordinate,
-    timestamp: number
+    timestampSecs: number
 }
 ```
 
@@ -129,8 +129,8 @@ type Outages = Outage[]
 interface Outage {
     id: number,
     body: string,
-    startTimestampMillis: number,
-    endTimestampMillis: number,
+    startTimestampSecs: number,
+    endTimestampSecs: number,
     routesDisabled: number[] // Route ID list
     stopsDisabled: number[] // Stop ID list
 }
@@ -151,8 +151,8 @@ POST `/admin/outage/`
 ```typescript
 interface Outage {
     body: string,
-    startTimestampMillis: number,
-    endTimestampMillis: number,
+    startTimestampSecs: number,
+    endTimestampSecs: number,
     routesDisabled: number[] // Route ID list
     stopsDisabled: number[] // Stop ID list
 }


### PR DESCRIPTION
Rework the frontend API spec to:
- Make it easier to use from the frontend, mostly by separating waypoints and stops, separating outages and alerts, and defining typescript interfaces for requests/responses
- Explicitly use JSON instead of any ad-hoc format
- Define some new endpoints due to new stakeholder requirements discussed earlier

Other non-frontend points are currently disregarded.