### PR TITLE
Frontend: Cleanup

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, SafeAreaView } from 'react-native'
 import * as NavigationBar from 'expo-navigation-bar'
-import { Main } from './src/Main'
+import Main from './src/Main'
 
 // -----
 // DO NOT PUT ANY SUBSTANTIAL UI OR LOGIC INTO THIS FILE. ONLY INCLUDE SYSTEM CONFIGURATION.
@@ -8,10 +8,10 @@ import { Main } from './src/Main'
 
 NavigationBar.setBackgroundColorAsync('white').catch(console.error)
 
-export default function App(): React.ReactElement<void> {
-  return (
-    <SafeAreaView style={StyleSheet.absoluteFillObject}>
-      <Main style={StyleSheet.absoluteFillObject} />
-    </SafeAreaView>
-  )
-}
+const App: React.FC<void> = () => (
+  <SafeAreaView style={StyleSheet.absoluteFillObject}>
+    <Main style={StyleSheet.absoluteFillObject} />
+  </SafeAreaView>
+)
+
+export default App

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,5 +1,6 @@
-import { StyleSheet, SafeAreaView } from 'react-native'
+import { SafeAreaView } from 'react-native'
 import * as NavigationBar from 'expo-navigation-bar'
+import LayoutStyle from './src/style/layout'
 import Main from './src/Main'
 
 // -----
@@ -9,8 +10,8 @@ import Main from './src/Main'
 NavigationBar.setBackgroundColorAsync('white').catch(console.error)
 
 const App: React.FC<void> = () => (
-  <SafeAreaView style={StyleSheet.absoluteFillObject}>
-    <Main style={StyleSheet.absoluteFillObject} />
+  <SafeAreaView style={LayoutStyle.fill}>
+    <Main style={LayoutStyle.fill} />
   </SafeAreaView>
 )
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2174,9 +2174,9 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "0.10.12",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.10.12.tgz",
-      "integrity": "sha512-sc4IkRBbm6HO1Z/0JeJMY/sJiyCAfHyt2EOHhAY8jYfbXr/aqCIGsPrwEGQAfGpsE2OPvyzRa+byZG03HRPTkQ==",
+      "version": "0.10.15",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.10.15.tgz",
+      "integrity": "sha512-CIpfIB5oB/s/op6Ke5M7TI4/yOi5raTR9ps9UD+ExazonTDAzEtXANVWmAR7Z4+wUyqycniWxTpICcaxri2a3A==",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/code-signing-certificates": "0.0.5",
@@ -2626,9 +2626,9 @@
       }
     },
     "node_modules/@expo/dev-server/node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2736,14 +2736,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@expo/env/node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/@expo/env/node_modules/has-flag": {
       "version": "4.0.0",
@@ -2869,9 +2861,9 @@
       }
     },
     "node_modules/@expo/image-utils/node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3060,9 +3052,9 @@
       }
     },
     "node_modules/@expo/package-manager": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.1.1.tgz",
-      "integrity": "sha512-NxtfIA25iEiNwMT+s8PEmdKzjyfWd2qkCLJkf6jKZGaH9c06YXyOAi2jvCyM8XuSzJz4pcEH8kz1HkJAInjB7Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.1.2.tgz",
+      "integrity": "sha512-JI9XzrxB0QVXysyuJ996FPCJGDCYRkbUvgG4QmMTTMFA1T+mv8YzazC3T9C1pHQUAAveVCre1+Pqv0nZXN24Xg==",
       "dependencies": {
         "@expo/json-file": "^8.2.37",
         "@expo/spawn-async": "^1.5.0",
@@ -3227,9 +3219,9 @@
       }
     },
     "node_modules/@expo/prebuild-config/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -8007,6 +7999,14 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dotenv-expand": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
@@ -8869,12 +8869,12 @@
       }
     },
     "node_modules/expo": {
-      "version": "49.0.11",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-49.0.11.tgz",
-      "integrity": "sha512-4UtSnaVn4bAEsdp2Z2I8okCJEmAm2cj1Rl3ifm79fI4zMz3EqBaXMKs6OdMSTa6DWq3dZp8C/5dEKy/ynah0CA==",
+      "version": "49.0.18",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-49.0.18.tgz",
+      "integrity": "sha512-BrPtTxBlE7pFG1ZDi1fqq4pGbS5IcTg4bH9TTeUbJOTTs43W+QkXzsylmT0omf8nADOHGx9EFgufPneBcU1F1w==",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.10.12",
+        "@expo/cli": "0.10.15",
         "@expo/config": "8.1.2",
         "@expo/config-plugins": "7.2.5",
         "@expo/vector-icons": "^13.0.0",
@@ -9076,9 +9076,9 @@
       }
     },
     "node_modules/expo-modules-autolinking/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "engines": {
         "node": ">= 10.0.0"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "ts:check": "tsc"
   },
   "dependencies": {
+    "@gorhom/bottom-sheet": "^4",
     "expo": "~49.0.8",
     "expo-location": "~16.1.0",
     "expo-navigation-bar": "~2.3.0",
@@ -18,10 +19,9 @@
     "prettier": "^3.0.3",
     "react": "18.2.0",
     "react-native": "0.72.5",
+    "react-native-gesture-handler": "~2.12.0",
     "react-native-maps": "1.7.1",
-    "@gorhom/bottom-sheet": "^4",
-    "react-native-reanimated": "~3.3.0",
-    "react-native-gesture-handler": "~2.12.0"
+    "react-native-reanimated": "~3.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/frontend/src/Main.tsx
+++ b/frontend/src/Main.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { StyleSheet, View, Text, Dimensions, type ViewProps } from 'react-native'
+import { View, Text, Dimensions, type ViewProps } from 'react-native'
 import Map from './components/Map'
 import Sheet from './components/Sheet'
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import LayoutStyle from './style/layout'
 
 /**
  * Controls the percentage of the screen taken up by the bottom sheet in
@@ -27,7 +28,7 @@ const Main: React.FC<ViewProps> = () => {
 
   return (
     <GestureHandlerRootView>
-      <Map style={StyleSheet.absoluteFill}
+      <Map style={LayoutStyle.fill}
         insets={mapInsets} />
       <Sheet collapsedExtent={SHEET_EXTENT}>
         <View>

--- a/frontend/src/Main.tsx
+++ b/frontend/src/Main.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { StyleSheet, View, Text, Dimensions, type ViewProps } from 'react-native'
-import { Map } from './components/Map'
-import { Sheet } from './components/Sheet'
+import Map from './components/Map'
+import Sheet from './components/Sheet'
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 /**
@@ -13,7 +13,7 @@ const SHEET_EXTENT = 0.5
 /**
  * The main screen containing the map and sheet components.
  */
-export function Main(_: ViewProps): React.ReactElement<void> {
+const Main: React.FC<ViewProps> = () => {
   // The bottom sheet extends halfway across the screen, with the map
   // being inset accordingly.
   const screenHeight = Dimensions.get('window').height
@@ -37,3 +37,5 @@ export function Main(_: ViewProps): React.ReactElement<void> {
     </GestureHandlerRootView>
   )
 }
+
+export default Main;

--- a/frontend/src/Main.tsx
+++ b/frontend/src/Main.tsx
@@ -18,13 +18,7 @@ const Main: React.FC<ViewProps> = () => {
   // The bottom sheet extends halfway across the screen, with the map
   // being inset accordingly.
   const screenHeight = Dimensions.get('window').height
-  const mapInsets = {
-    top: 0,
-    left: 0,
-    // Inset the map so that elements are not obscured by the bottom sheet
-    bottom: screenHeight * SHEET_EXTENT,
-    right: 0
-  }
+  const mapInsets = { bottom: screenHeight * SHEET_EXTENT }
 
   return (
     <GestureHandlerRootView>

--- a/frontend/src/components/LocationButton.tsx
+++ b/frontend/src/components/LocationButton.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+
 import { TouchableHighlight, StyleSheet, type ViewProps, View } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 
 /**
  * The props for the {@function LocationButton} component.
  */
-export interface LocationButtonProps {
+export interface LocationButtonProps extends ViewProps {
   /** Whether the button should display that the user location is actively being followed. */
   isActive: boolean,
   /** Callback for when the button is pressed by the user. */
@@ -15,7 +16,7 @@ export interface LocationButtonProps {
 /**
  * A button that toggles whether the user's location is being followed.
  */
-export function LocationButton(props: ViewProps & LocationButtonProps): React.ReactElement {
+const LocationButton: React.FC<LocationButtonProps> = (props) => {
   return (
     <TouchableHighlight style={styles.button} underlayColor="#DDDDDD" onPress={props.onPress}>
       <View>
@@ -44,3 +45,5 @@ const styles = StyleSheet.create({
     elevation: 8,
   },
 })
+
+export default LocationButton;

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -1,8 +1,9 @@
 import MapView, { PROVIDER_GOOGLE } from 'react-native-maps'
-import { View, StyleSheet, type ViewProps, StatusBar, type StyleProp, type ViewStyle } from 'react-native'
+import { View, type ViewProps, StatusBar, type StyleProp, type ViewStyle } from 'react-native'
 import { type Coordinate } from '../services/location'
 import LocationButton from './LocationButton'
 import React, { useRef, useMemo, useState } from 'react'
+import LayoutStyle from '../style/layout'
 
 interface MapProps extends ViewProps {
   /** 
@@ -63,7 +64,6 @@ const Map: React.FC<MapProps> = ({ insets }) => {
 
   // Insets + 16dp padding & Bottom-end alignment
   const locationButtonContainerStyle: StyleProp<ViewStyle> = {
-    ...StyleSheet.absoluteFillObject,
     paddingTop: padding.top + 16,
     paddingBottom: padding.bottom + 16,
     paddingLeft: padding.left + 16,
@@ -74,7 +74,7 @@ const Map: React.FC<MapProps> = ({ insets }) => {
 
   return (
     <View>
-      <MapView style={styles.innerMap}
+      <MapView style={LayoutStyle.fill}
         ref={mapRef}
         provider={PROVIDER_GOOGLE}
         showsUserLocation={true}
@@ -83,7 +83,7 @@ const Map: React.FC<MapProps> = ({ insets }) => {
         onPanDrag={() => { setFollowingLocation(false) }}
         onUserLocationChange={event => { updateLocation(event.nativeEvent.coordinate) }} />
       { /* Layer the location button on the map instead of displacing it. */ }
-      <View style={locationButtonContainerStyle}>
+      <View style={[LayoutStyle.overlay, locationButtonContainerStyle]}>
         <LocationButton isActive={followingLocation} 
           onPress={() => { flipFollowingLocation() }} />
       </View>
@@ -101,12 +101,5 @@ export interface Insets {
   /** The amount of space to inset from the right of the map. */
   right: number
 }
-
-const styles = StyleSheet.create({
-  innerMap: {
-    width: '100%',
-    height: '100%'
-  }
-})
 
 export default Map;

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -1,9 +1,10 @@
 import MapView, { PROVIDER_GOOGLE } from 'react-native-maps'
-import { View, type ViewProps, StatusBar, type StyleProp, type ViewStyle } from 'react-native'
+import { View, StyleSheet, type ViewProps, StatusBar } from 'react-native'
 import { type Coordinate } from '../services/location'
 import LocationButton from './LocationButton'
 import React, { useRef, useMemo, useState } from 'react'
 import LayoutStyle from '../style/layout'
+import SpacingStyle, { type Insets } from '../style/spacing'
 
 interface MapProps extends ViewProps {
   /** 
@@ -62,16 +63,6 @@ const Map: React.FC<MapProps> = ({ insets }) => {
     right: (insets?.right ?? 0)
   }
 
-  // Insets + 16dp padding & Bottom-end alignment
-  const locationButtonContainerStyle: StyleProp<ViewStyle> = {
-    paddingTop: padding.top + 16,
-    paddingBottom: padding.bottom + 16,
-    paddingLeft: padding.left + 16,
-    paddingRight: padding.right + 16,
-    justifyContent: 'flex-end',
-    alignItems: 'flex-end'
-  }
-
   return (
     <View>
       <MapView style={LayoutStyle.fill}
@@ -83,7 +74,7 @@ const Map: React.FC<MapProps> = ({ insets }) => {
         onPanDrag={() => { setFollowingLocation(false) }}
         onUserLocationChange={event => { updateLocation(event.nativeEvent.coordinate) }} />
       { /* Layer the location button on the map instead of displacing it. */ }
-      <View style={[LayoutStyle.overlay, locationButtonContainerStyle]}>
+      <View style={[LayoutStyle.overlay, SpacingStyle.pad(padding, 16), styles.locationButtonContainer]}>
         <LocationButton isActive={followingLocation} 
           onPress={() => { flipFollowingLocation() }} />
       </View>
@@ -91,15 +82,11 @@ const Map: React.FC<MapProps> = ({ insets }) => {
   )
 }
 
-export interface Insets {
-  /** The amount of space to inset from the top of the map. */
-  top: number,
-  /** The amount of space to inset from the left of the map. */
-  left: number,
-  /** The amount of space to inset from the bottom of the map. */
-  bottom: number,
-  /** The amount of space to inset from the right of the map. */
-  right: number
-}
+const styles = StyleSheet.create({
+  locationButtonContainer: {
+    justifyContent: 'flex-end',
+    alignItems: 'flex-end'
+  }
+})
 
 export default Map;

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -1,13 +1,21 @@
 import MapView, { PROVIDER_GOOGLE } from 'react-native-maps'
 import { View, StyleSheet, type ViewProps, StatusBar, type StyleProp, type ViewStyle } from 'react-native'
 import { type Coordinate } from '../services/location'
-import { LocationButton } from './LocationButton'
+import LocationButton from './LocationButton'
 import React, { useRef, useMemo, useState } from 'react'
+
+interface MapProps extends ViewProps {
+  /** 
+   * The {@interface Insets} to pad map information with. Useful if map information will be
+   * obscured. Note that status bar insets will already be applied, so don't include those.
+   */
+  insets?: Insets
+}
 
 /**
  * A wrapper around react native {@class MapView} that provides a simplified interface for the purposes of this app.
  */
-export function Map(props: MapProps & ViewProps): React.ReactElement<MapProps & ViewProps> {
+const Map: React.FC<MapProps> = ({ insets }) => {
   const mapRef = useRef<MapView>(null)
   const [followingLocation, setFollowingLocation] = useState<boolean>(true)
   const [lastLocation, setLastLocation] = React.useState<Coordinate | undefined>(undefined)
@@ -47,10 +55,10 @@ export function Map(props: MapProps & ViewProps): React.ReactElement<MapProps & 
   // is fully in-bounds.
   const statusBarInset = useMemo(() => StatusBar.currentHeight ?? 0, [])
   const padding = {
-    top: (props.insets?.top ?? 0) + statusBarInset,
-    left: (props.insets?.left ?? 0),
-    bottom: (props.insets?.bottom ?? 0),
-    right: (props.insets?.right ?? 0)
+    top: (insets?.top ?? 0) + statusBarInset,
+    left: (insets?.left ?? 0),
+    bottom: (insets?.bottom ?? 0),
+    right: (insets?.right ?? 0)
   }
 
   // Insets + 16dp padding & Bottom-end alignment
@@ -83,21 +91,6 @@ export function Map(props: MapProps & ViewProps): React.ReactElement<MapProps & 
   )
 }
 
-/**
- * The props for the {@function Map} component.
- */
-export interface MapProps {
-  /** 
-   * The {@interface Insets} to pad map information with. Useful if map information will be
-   * obscured. Note that status bar insets will already be applied, so don't include those.
-   */
-  insets?: Insets
-}
-
-/**
- * The insets to apply to the {@interface Map} component when it will be obscured by
- * other components. {@see MapProps.insets}
- */
 export interface Insets {
   /** The amount of space to inset from the top of the map. */
   top: number,
@@ -115,3 +108,5 @@ const styles = StyleSheet.create({
     height: '100%'
   }
 })
+
+export default Map;

--- a/frontend/src/components/Sheet.tsx
+++ b/frontend/src/components/Sheet.tsx
@@ -5,7 +5,7 @@ import BottomSheet from '@gorhom/bottom-sheet'
 /**
  * Wraps the bottom sheet component with a simplified interface.
  */
-export function Sheet(props: SheetProps & ViewProps): React.ReactElement<SheetProps & ViewProps> {
+const Sheet: React.FC<SheetProps> = ({collapsedExtent, children}) => {
   // BottomSheet does have a topInset property, but that causes the shadow of the bottom
   // sheet to become clipped at the top for some reason. Instead, we manually recreate it
   // by adjusting our snap points such that they will cause the sheet to never overlap the
@@ -17,7 +17,7 @@ export function Sheet(props: SheetProps & ViewProps): React.ReactElement<SheetPr
   const expandedPercent = 100 * screenHeight / (screenHeight + statusBarHeight)
   // Then we can adjust that calculated value by the specified extent of the collapsed
   // bottom sheet.
-  const collapsedPercent = props.collapsedExtent * expandedPercent
+  const collapsedPercent = collapsedExtent * expandedPercent
   const snapPoints = [collapsedPercent + '%', expandedPercent + '%']
 
   return (
@@ -26,7 +26,7 @@ export function Sheet(props: SheetProps & ViewProps): React.ReactElement<SheetPr
       index={0}
       enableOverDrag={false}
       snapPoints={snapPoints}>
-      {props.children}
+      {children}
     </BottomSheet>
   )
 }
@@ -34,7 +34,7 @@ export function Sheet(props: SheetProps & ViewProps): React.ReactElement<SheetPr
 /**
  * The props for the {@interface Sheet} component.
  */
-export interface SheetProps {
+export interface SheetProps extends ViewProps {
   /** How much of the bottom sheet to show initially as a fraction of the screen, such as '0.5' for half of the screen */
   collapsedExtent: number,
   /** The child view of the bottom sheet */
@@ -56,3 +56,5 @@ const styles = StyleSheet.create({
     elevation: 24,
   }
 })
+
+export default Sheet;

--- a/frontend/src/style/layout.ts
+++ b/frontend/src/style/layout.ts
@@ -1,0 +1,13 @@
+import { StyleSheet } from 'react-native'
+
+export default StyleSheet.create({
+  fill: {
+    width: '100%',
+    height: '100%'
+  },
+  overlay: {
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+  }
+})

--- a/frontend/src/style/spacing.ts
+++ b/frontend/src/style/spacing.ts
@@ -1,0 +1,30 @@
+import { type ViewStyle } from "react-native"
+
+export interface Insets {
+  /** The amount of space to inset from the top of the map. 0 if not specified. */
+  top?: number,
+  /** The amount of space to inset from the left of the map. 0 if not specified. */
+  left?: number,
+  /** The amount of space to inset from the bottom of the map. 0 if not specified. */
+  bottom?: number,
+  /** The amount of space to inset from the right of the map. 0 if not specified. */
+  right?: number
+}
+
+/**
+ * Transforms an existing padding value into a {@type ViewStyle} by adding the specified amount to
+ * each side.
+ * @param existingPadding The existing padding.
+ * @param amount The amount to add to each side.
+ * @returns The {@type ViewStyle} representing the new padding.
+ */
+function pad(existingPadding: Insets, amount: number): ViewStyle {
+  return {
+    paddingTop: (existingPadding.top ?? 0) + amount,
+    paddingLeft: (existingPadding.left ?? 0) + amount,
+    paddingBottom: (existingPadding.bottom ?? 0) + amount,
+    paddingRight: (existingPadding.right ?? 0) + amount
+  }
+}
+
+export default { pad }


### PR DESCRIPTION
- Split off reused styles and janky component properties for shared functions in a new styles module
- Use proper `React.FC` notation for all components
- Update expo