### PR TITLE
Remove unneeded include parameters

### DIFF
--- a/backend/src/handlers/alert.py
+++ b/backend/src/handlers/alert.py
@@ -27,23 +27,16 @@ def get_alerts(
     with req.app.state.db.session() as session:
         alerts: List[Alert] = session.query(Alert).all()
 
-    resp: Dict[str, List[Dict[str, Union[str, int]]]] = {"alerts": []}
-    for alert in alerts:
-        filtered_alert: Dict[str, Union[str, int]] = {}
+    alerts_json: List[Dict[str, Union[str, int]]] = [
+        {
+            "text": alert.text,
+            "startDateTime": str(alert.start_datetime),
+            "endDateTime": str(alert.end_datetime)
+        }
+        for alert in alerts
+    ]
 
-        filtered_alert["id"] = alert.id
-        if include is None or "text" in include:
-            filtered_alert["text"] = alert.text
-
-        if include is None or "start" in include:
-            filtered_alert["start"] = str(alert.start_datetime)
-
-        if include is None or "end" in include:
-            filtered_alert["end"] = str(alert.end_datetime)
-
-        resp["alerts"].append(filtered_alert)
-
-    return JSONResponse(content=resp)
+    return JSONResponse(content=alerts_json)
 
 
 @router.get("/{alert_id}")
@@ -54,19 +47,14 @@ def get_alert(
         alert: Alert = session.query(Alert).filter_by(id=alert_id).first()
         if alert is None:
             return JSONResponse(content={"message": "Alert not found"}, status_code=404)
+    
+    alert_json = {
+        "text": alert.text,
+        "startDateTime": str(alert.start_datetime),
+        "endDateTime": str(alert.end_datetime)
+    }
 
-    filtered_alert = {}
-
-    if include is None or "text" in include:
-        filtered_alert["text"] = alert.text
-
-    if include is None or "start" in include:
-        filtered_alert["start"] = str(alert.start_datetime)
-
-    if include is None or "end" in include:
-        filtered_alert["end"] = str(alert.end_datetime)
-
-    return JSONResponse(content=filtered_alert)
+    return JSONResponse(content=alert_json)
 
 
 @router.post("/")

--- a/backend/src/handlers/alert.py
+++ b/backend/src/handlers/alert.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Dict, List, Union
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from src.model.alert import Alert

--- a/backend/src/handlers/alert.py
+++ b/backend/src/handlers/alert.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Dict, List, Union
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
@@ -28,7 +29,7 @@ def get_alerts(req: Request, active: bool = False) -> JSONResponse:
             query = query.filter(Alert.start_datetime <= now, Alert.end_datetime >= now)
         alerts = query.all()
 
-    alerts_json = []
+    alerts_json: List[Dict[str, Union[str, int]]] = []
     for alert in alerts:
         alert_json = {
             "text": alert.text,

--- a/backend/src/handlers/alert.py
+++ b/backend/src/handlers/alert.py
@@ -21,9 +21,7 @@ class AlertModel(BaseModel):
 
 
 @router.get("/")
-def get_alerts(
-    req: Request, include: Union[List[str], None] = Query(default=None)
-) -> JSONResponse:
+def get_alerts(req: Request) -> JSONResponse:
     with req.app.state.db.session() as session:
         alerts: List[Alert] = session.query(Alert).all()
 
@@ -31,7 +29,7 @@ def get_alerts(
         {
             "text": alert.text,
             "startDateTime": str(alert.start_datetime),
-            "endDateTime": str(alert.end_datetime)
+            "endDateTime": str(alert.end_datetime),
         }
         for alert in alerts
     ]
@@ -40,18 +38,16 @@ def get_alerts(
 
 
 @router.get("/{alert_id}")
-def get_alert(
-    req: Request, alert_id: int, include: Union[List[str], None] = Query(default=None)
-) -> JSONResponse:
+def get_alert(req: Request, alert_id: int) -> JSONResponse:
     with req.app.state.db.session() as session:
         alert: Alert = session.query(Alert).filter_by(id=alert_id).first()
         if alert is None:
             return JSONResponse(content={"message": "Alert not found"}, status_code=404)
-    
+
     alert_json = {
         "text": alert.text,
         "startDateTime": str(alert.start_datetime),
-        "endDateTime": str(alert.end_datetime)
+        "endDateTime": str(alert.end_datetime),
     }
 
     return JSONResponse(content=alert_json)

--- a/backend/src/handlers/routes.py
+++ b/backend/src/handlers/routes.py
@@ -3,7 +3,7 @@ Contains routes specific to working with routes.
 """
 
 from datetime import datetime, timezone
-from typing import Annotated, Any, Iterator, Optional
+from typing import Annotated, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from src.model.alert import Alert
@@ -52,11 +52,8 @@ def get_routes(
             )
 
         routes_json = []
-        for route in routes:  
-            route_json = {
-                FIELD_ID: route.id,
-                FIELD_NAME: route.name
-            }
+        for route in routes:
+            route_json = {FIELD_ID: route.id, FIELD_NAME: route.name}
 
             # Add related values to the route if included
             if FIELD_STOP_IDS in include_set:
@@ -68,9 +65,7 @@ def get_routes(
             # Already checked if included later when we fetched the alert, check for it's
             # presence.
             if alert:
-                route_json[FIELD_IS_ACTIVE] = is_route_active(
-                    route.id, alert, session
-                )
+                route_json[FIELD_IS_ACTIVE] = is_route_active(route.id, alert, session)
 
             routes_json.append(route_json)
 
@@ -92,11 +87,8 @@ def get_route(
         route = session.query(Route).filter(Route.id == route_id).first()
         if not route:
             raise HTTPException(status_code=404, detail="Route not found")
-        
-        route_json = {
-            FIELD_ID: route.id,
-            FIELD_NAME: route.name
-        }
+
+        route_json = {FIELD_ID: route.id, FIELD_NAME: route.name}
 
         # Add related values to the route if included
         if FIELD_STOP_IDS in include_set:
@@ -112,6 +104,7 @@ def get_route(
             route_json[FIELD_IS_ACTIVE] = is_route_active(route.id, alert, session)
 
         return route_json
+
 
 def query_route_stop_ids(route_id: int, session):
     """

--- a/backend/src/handlers/routes.py
+++ b/backend/src/handlers/routes.py
@@ -22,7 +22,6 @@ FIELD_IS_ACTIVE = "isActive"
 FIELD_LATITUDE = "latitude"
 FIELD_LONGITUDE = "longitude"
 INCLUDES = {
-    FIELD_NAME,
     FIELD_STOP_IDS,
     FIELD_WAYPOINTS,
     FIELD_IS_ACTIVE,
@@ -42,8 +41,7 @@ def get_routes(
 
     include_set = process_include(include, INCLUDES)
     with req.app.state.db.session() as session:
-        query = session.query(Route)
-        query, entities = apply_includes_to_query(query, include_set)
+        routes = session.query(Route).all()
 
         # Be more efficient and load the current alert only once if
         # we need it for the isActive field.
@@ -53,27 +51,30 @@ def get_routes(
                 datetime.now(timezone.utc).replace(tzinfo=None), session
             )
 
-        routes = []
-        for route in query.all():
-            route = unpack_entity_tuple(route, entities)
+        routes_json = []
+        for route in routes:  
+            route_json = {
+                FIELD_ID: route.id,
+                FIELD_NAME: route.name
+            }
 
             # Add related values to the route if included
             if FIELD_STOP_IDS in include_set:
-                route[FIELD_STOP_IDS] = query_route_stop_ids(route[FIELD_ID], session)
+                route_json[FIELD_STOP_IDS] = query_route_stop_ids(route.id, session)
 
             if FIELD_WAYPOINTS in include_set:
-                route[FIELD_WAYPOINTS] = query_route_waypoints(route[FIELD_ID], session)
+                route_json[FIELD_WAYPOINTS] = query_route_waypoints(route.id, session)
 
             # Already checked if included later when we fetched the alert, check for it's
             # presence.
             if alert:
-                route[FIELD_IS_ACTIVE] = is_route_active(
-                    route[FIELD_ID], alert, session
+                route_json[FIELD_IS_ACTIVE] = is_route_active(
+                    route.id, alert, session
                 )
 
-            routes.append(route)
+            routes_json.append(route_json)
 
-        return routes
+        return routes_json
 
 
 @router.get("/{route_id}")
@@ -88,53 +89,29 @@ def get_route(
 
     include_set = process_include(include, INCLUDES)
     with req.app.state.db.session() as session:
-        query = session.query(Route).filter(Route.id == route_id)
-        query, entities = apply_includes_to_query(query, include_set)
-        route = query.first()
+        route = session.query(Route).filter(Route.id == route_id).first()
         if not route:
             raise HTTPException(status_code=404, detail="Route not found")
-
-        route = unpack_entity_tuple(route, entities)
+        
+        route_json = {
+            FIELD_ID: route.id,
+            FIELD_NAME: route.name
+        }
 
         # Add related values to the route if included
         if FIELD_STOP_IDS in include_set:
-            route[FIELD_STOP_IDS] = query_route_stop_ids(route[FIELD_ID], session)
+            route_json[FIELD_STOP_IDS] = query_route_stop_ids(route.id, session)
 
         if FIELD_WAYPOINTS in include_set:
-            route[FIELD_WAYPOINTS] = query_route_waypoints(route[FIELD_ID], session)
+            route_json[FIELD_WAYPOINTS] = query_route_waypoints(route.id, session)
 
         if FIELD_IS_ACTIVE in include_set:
             alert = get_current_alert(
                 datetime.now(timezone.utc).replace(tzinfo=None), session
             )
-            route[FIELD_IS_ACTIVE] = is_route_active(route[FIELD_ID], alert, session)
+            route_json[FIELD_IS_ACTIVE] = is_route_active(route.id, alert, session)
 
-        return route
-
-
-def apply_includes_to_query(query, include_set) -> tuple[Any, Iterator[str]]:
-    """
-    Applies the given include parameters to the given query, reducing the query to only
-    the fields that are desired. Since this will cause the query to return a tuple, a
-    dictionary is also provided of the names for each value that will appear in the tuple
-    in-order. This can be used with unpack_stop_values can be used to turn the tuple into
-    a JSON structure.
-    """
-
-    entities: dict[str, Any] = {FIELD_ID: Route.id}
-    if FIELD_NAME in include_set:
-        entities[FIELD_NAME] = Route.name
-
-    return (query.with_entities(*entities.values()), iter(entities.keys()))
-
-
-def unpack_entity_tuple(result: tuple, entities: Iterator[str]) -> dict:
-    """
-    Given a tuple of values and a list of the names for each value, returns a dictionary
-    mapping each name to its corresponding value.
-    """
-    return {key: value for key, value in zip(entities, result)}
-
+        return route_json
 
 def query_route_stop_ids(route_id: int, session):
     """

--- a/backend/src/handlers/stops.py
+++ b/backend/src/handlers/stops.py
@@ -3,7 +3,7 @@ Contains routes specific to working with stops.
 """
 
 from datetime import datetime, timezone
-from typing import Annotated, Any, Iterator, Optional
+from typing import Annotated, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from src.model.alert import Alert
@@ -86,7 +86,7 @@ def get_stop(
         stop = session.query(Stop).filter(Stop.id == stop_id).first()
         if not stop:
             raise HTTPException(status_code=404, detail="Stop not found")
-        
+
         stop_json = {
             FIELD_ID: stop.id,
             FIELD_NAME: stop.name,
@@ -102,7 +102,7 @@ def get_stop(
             stop_json[FIELD_IS_ACTIVE] = is_stop_active(stop, alert, session)
 
         if FIELD_ROUTE_IDS in include_set:
-            stop_json[FIELD_ROUTE_IDS] = query_route_ids(stop[FIELD_ID], session)
+            stop_json[FIELD_ROUTE_IDS] = query_route_ids(stop.id, session)
 
         return stop_json
 

--- a/backend/src/request.py
+++ b/backend/src/request.py
@@ -10,7 +10,7 @@ def process_include(include: Optional[list[str]], allowed: set[str]):
     """
     if include is None:
         # Nothing specified, implied to include all fields
-        return allowed
+        return {}
 
     include_set = set(include)
     if len(include_set) != len(include):


### PR DESCRIPTION
Include parameters (as Shane said) should:
1. Not be enabled by default.
2. Only apply to fields that require a JOIN to obtain.

This PR changes all of the current routes to follow that rule.