### PR TITLE
Backend: Fix routes/stops being always inactive

### DIFF
--- a/backend/src/handlers/routes.py
+++ b/backend/src/handlers/routes.py
@@ -65,7 +65,7 @@ def get_routes(
 
             # Already checked if included later when we fetched the alert, check for it's
             # presence.
-            if alert:
+            if FIELD_IS_ACTIVE in include_set:
                 route_json[FIELD_IS_ACTIVE] = is_route_active(route.id, alert, session)
 
             routes_json.append(route_json)

--- a/backend/src/handlers/routes.py
+++ b/backend/src/handlers/routes.py
@@ -63,8 +63,6 @@ def get_routes(
             if FIELD_WAYPOINTS in include_set:
                 route_json[FIELD_WAYPOINTS] = query_route_waypoints(route.id, session)
 
-            # Already checked if included later when we fetched the alert, check for it's
-            # presence.
             if FIELD_IS_ACTIVE in include_set:
                 route_json[FIELD_IS_ACTIVE] = is_route_active(route.id, alert, session)
 

--- a/backend/src/handlers/stops.py
+++ b/backend/src/handlers/stops.py
@@ -63,7 +63,7 @@ def get_stops(
 
             # Already checked if included later when we fetched the alert, check for it's
             # presence.
-            if alert:
+            if FIELD_IS_ACTIVE in include_set:
                 stop_json[FIELD_IS_ACTIVE] = is_stop_active(stop, alert, session)
 
             stops_json.append(stop_json)

--- a/backend/src/handlers/stops.py
+++ b/backend/src/handlers/stops.py
@@ -61,8 +61,6 @@ def get_stops(
             if FIELD_ROUTE_IDS in include_set:
                 stop_json[FIELD_ROUTE_IDS] = query_route_ids(stop.id, session)
 
-            # Already checked if included later when we fetched the alert, check for it's
-            # presence.
             if FIELD_IS_ACTIVE in include_set:
                 stop_json[FIELD_IS_ACTIVE] = is_stop_active(stop, alert, session)
 


### PR DESCRIPTION
Accidentally assumed that alert existing == isActive included, but that does not count for the case where we include isActive and it's actually false and there's no active alert. Fix that.