### PR TITLE
Backend: More tests

### DIFF
--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -23,7 +23,6 @@ jobs:
         working-directory: ./backend
       - run: mypy ./
         working-directory: ./backend
-      - run: pylint --rcfile ./pylintrc -E ./
-        working-directory: ./backend
+      - run: pylint --rcfile ./backend/pylintrc -E ./backend
       - run: pytest ./
         working-directory: ./backend

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -15,9 +15,15 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10.13"
-      - run: pip install -r ./backend/requirements.txt
-      - run: black --check --diff ./backend/
-      - run: isort --profile black --check --diff ./backend/
-      - run: mypy ./backend/
-      - run: pylint --rcfile ./backend/pylintrc -E ./backend/
-      - run: pytest ./backend/
+      - run: pip install -r ./requirements.txt
+        working-directory: ./backend
+      - run: black --check --diff ./
+        working-directory: ./backend
+      - run: isort --profile black --check --diff ./
+        working-directory: ./backend
+      - run: mypy ./
+        working-directory: ./backend
+      - run: pylint --rcfile ./pylintrc -E ./
+        working-directory: ./backend
+      - run: pytest ./
+        working-directory: ./backend

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,9 +1,10 @@
 from logging.config import fileConfig
 from os import getenv
 
-from alembic import context
 from dotenv import load_dotenv
 from sqlalchemy import engine_from_config, pool
+
+from alembic import context
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/backend/src/handlers/alert.py
+++ b/backend/src/handlers/alert.py
@@ -51,6 +51,7 @@ def get_alert(req: Request, alert_id: int) -> Dict[str, Union[str, int]]:
             return JSONResponse(content={"message": "Alert not found"}, status_code=404)
 
     alert_json: Dict[str, Union[str, int]] = {
+        "id": alert.id,
         "text": alert.text,
         "startDateTime": int(alert.start_datetime.timestamp()),
         "endDateTime": int(alert.end_datetime.timestamp()),

--- a/backend/src/handlers/alert.py
+++ b/backend/src/handlers/alert.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Union
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+
 from src.model.alert import Alert
 
 router = APIRouter(prefix="/alerts", tags=["alerts"])
@@ -21,7 +22,7 @@ class AlertModel(BaseModel):
 
 
 @router.get("/")
-def get_alerts(req: Request, active: bool = False) -> JSONResponse:
+def get_alerts(req: Request, active: bool = False) -> List[Dict[str, Union[str, int]]]:
     with req.app.state.db.session() as session:
         query = session.query(Alert)
         if active:
@@ -39,27 +40,27 @@ def get_alerts(req: Request, active: bool = False) -> JSONResponse:
         }
         alerts_json.append(alert_json)
 
-    return JSONResponse(content=alerts_json)
+    return alerts_json
 
 
 @router.get("/{alert_id}")
-def get_alert(req: Request, alert_id: int) -> JSONResponse:
+def get_alert(req: Request, alert_id: int) -> Dict[str, Union[str, int]]:
     with req.app.state.db.session() as session:
         alert: Alert = session.query(Alert).filter_by(id=alert_id).first()
         if alert is None:
             return JSONResponse(content={"message": "Alert not found"}, status_code=404)
 
-    alert_json = {
+    alert_json: Dict[str, Union[str, int]] = {
         "text": alert.text,
         "startDateTime": int(alert.start_datetime.timestamp()),
         "endDateTime": int(alert.end_datetime.timestamp()),
     }
 
-    return JSONResponse(content=alert_json)
+    return alert_json
 
 
 @router.post("/")
-def post_alert(req: Request, alert_model: AlertModel) -> JSONResponse:
+def post_alert(req: Request, alert_model: AlertModel) -> Dict[str, str]:
     with req.app.state.db.session() as session:
         dt_start_time = datetime.fromtimestamp(alert_model.start_time, timezone.utc)
         dt_end_time = datetime.fromtimestamp(alert_model.end_time, timezone.utc)
@@ -72,11 +73,13 @@ def post_alert(req: Request, alert_model: AlertModel) -> JSONResponse:
         session.add(alert)
         session.commit()
 
-    return JSONResponse(content={"message": "OK"})
+    return {"message": "OK"}
 
 
 @router.put("/{alert_id}")
-def update_alert(req: Request, alert_id: int, alert_model: AlertModel) -> JSONResponse:
+def update_alert(
+    req: Request, alert_id: int, alert_model: AlertModel
+) -> Dict[str, str]:
     with req.app.state.db.session() as session:
         alert: Alert = session.query(Alert).filter_by(id=alert_id).first()
         if alert is None:
@@ -90,11 +93,11 @@ def update_alert(req: Request, alert_id: int, alert_model: AlertModel) -> JSONRe
         alert.end_datetime = dt_end_time
         session.commit()
 
-    return JSONResponse(content={"message": "OK"})
+    return {"message": "OK"}
 
 
 @router.delete("/{alert_id}")
-def delete_alert(req: Request, alert_id: int) -> JSONResponse:
+def delete_alert(req: Request, alert_id: int) -> Dict[str, str]:
     with req.app.state.db.session() as session:
         alert: Alert = session.query(Alert).filter_by(id=alert_id).first()
         if alert is None:
@@ -102,4 +105,4 @@ def delete_alert(req: Request, alert_id: int) -> JSONResponse:
         session.query(Alert).filter_by(id=alert_id).delete()
         session.commit()
 
-    return JSONResponse(content={"message": "OK"})
+    return {"message": "OK"}

--- a/backend/src/handlers/ridership.py
+++ b/backend/src/handlers/ridership.py
@@ -4,12 +4,13 @@ Routes for tracking ridership statistics.
 
 import struct
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional
+from typing import List, Optional, Dict, Union
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, model_validator
 from sqlalchemy.sql import ColumnElement
+
 from src.hardware import HardwareErrorCode, HardwareHTTPException, HardwareOKResponse
 from src.model.analytics import Analytics
 from src.model.van import Van
@@ -133,7 +134,7 @@ async def post_ridership_stats(req: Request, van_id: int):
 @router.get("/")
 def get_ridership(
     req: Request, filters: Optional[RidershipFilterModel]
-) -> JSONResponse:
+) -> List[Dict[str, Union[str, int, float]]]:
     with req.app.state.db.session() as session:
         analytics: List[Analytics] = []
         if filters is None or filters.filters is None:
@@ -142,7 +143,7 @@ def get_ridership(
             analytics = session.query(Analytics).filter(*filters.filters).all()
 
     # convert analytics to json
-    analytics_json = []
+    analytics_json: List[Dict[str, Union[str, int, float]]] = []
     for analytic in analytics:
         analytics_json.append(
             {
@@ -156,4 +157,4 @@ def get_ridership(
             }
         )
 
-    return JSONResponse(content=analytics_json)
+    return analytics_json

--- a/backend/src/handlers/ridership.py
+++ b/backend/src/handlers/ridership.py
@@ -4,7 +4,7 @@ Routes for tracking ridership statistics.
 
 import struct
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional, Dict, Union
+from typing import Dict, List, Optional, Union
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse

--- a/backend/src/handlers/routes.py
+++ b/backend/src/handlers/routes.py
@@ -9,6 +9,7 @@ from typing import Annotated, Optional
 from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+
 from src.model.alert import Alert
 from src.model.route import Route
 from src.model.route_disable import RouteDisable

--- a/backend/src/handlers/stops.py
+++ b/backend/src/handlers/stops.py
@@ -6,7 +6,6 @@ from datetime import datetime, timezone
 from typing import Annotated, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from src.model.alert import Alert
 from src.model.route_stop import RouteStop
@@ -166,7 +165,7 @@ class StopModel(BaseModel):
 
 
 @router.post("/")
-def create_stop(req: Request, stop_model: StopModel) -> JSONResponse:
+def create_stop(req: Request, stop_model: StopModel) -> dict[str, str]:
     """
     Creates a new stop.
     """
@@ -181,7 +180,7 @@ def create_stop(req: Request, stop_model: StopModel) -> JSONResponse:
         session.add(stop)
         session.commit()
 
-    return JSONResponse(content={"message": "OK"})
+    return {"message": "OK"}
 
 
 @router.put("/{stop_id}")
@@ -189,7 +188,7 @@ def update_stop(
     req: Request,
     stop_id: int,
     stop_model: StopModel,
-) -> JSONResponse:
+) -> dict[str, str]:
     """
     Updates the stop with the specified id.
     """
@@ -205,11 +204,11 @@ def update_stop(
 
         session.commit()
 
-    return JSONResponse(content={"message": "OK"})
+    return {"message": "OK"}
 
 
 @router.delete("/{stop_id}")
-def delete_stop(req: Request, stop_id: int) -> JSONResponse:
+def delete_stop(req: Request, stop_id: int) -> dict[str, str]:
     """
     Deletes the stop with the specified id.
     """
@@ -222,4 +221,4 @@ def delete_stop(req: Request, stop_id: int) -> JSONResponse:
         session.query(Stop).filter(Stop.id == stop_id).delete()
         session.commit()
 
-    return JSONResponse(content={"message": "OK"})
+    return {"message": "OK"}

--- a/backend/src/handlers/stops.py
+++ b/backend/src/handlers/stops.py
@@ -7,6 +7,7 @@ from typing import Annotated, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
+
 from src.model.alert import Alert
 from src.model.route_stop import RouteStop
 from src.model.stop import Stop

--- a/backend/src/handlers/vans.py
+++ b/backend/src/handlers/vans.py
@@ -9,6 +9,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 from starlette.responses import Response
+
 from src.hardware import HardwareErrorCode, HardwareHTTPException, HardwareOKResponse
 from src.model.van import Van
 from src.request import process_include

--- a/backend/src/handlers/vans.py
+++ b/backend/src/handlers/vans.py
@@ -8,10 +8,10 @@ from fastapi import APIRouter, HTTPException, Query, Request, WebSocket
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
+from starlette.responses import Response
 from src.hardware import HardwareErrorCode, HardwareHTTPException, HardwareOKResponse
 from src.model.van import Van
 from src.request import process_include
-from starlette.responses import Response
 
 
 class VanModel(BaseModel):

--- a/backend/src/model/alert.py
+++ b/backend/src/model/alert.py
@@ -2,7 +2,9 @@ from datetime import datetime
 
 from sqlalchemy import DateTime
 from sqlalchemy.orm import Mapped, mapped_column
+
 from src.db import Base
+from src.model.types import TZDateTime
 
 
 class Alert(Base):
@@ -11,5 +13,17 @@ class Alert(Base):
         primary_key=True, autoincrement=True, nullable=False
     )
     text: Mapped[str] = mapped_column(nullable=False)
-    start_datetime: Mapped[datetime] = mapped_column(DateTime, nullable=False)
-    end_datetime: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    start_datetime: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
+    end_datetime: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
+
+    def __eq__(self, __value: object) -> bool:
+        # Exclude ID since it'll always differ, only compare on content
+        return (
+            isinstance(__value, Alert)
+            and self.text == __value.text
+            and self.start_datetime == __value.start_datetime
+            and self.end_datetime == __value.end_datetime
+        )
+
+    def __repr__(self) -> str:
+        return f"<Alert id={self.id} text={self.text} start_datetime={self.start_datetime} end_datetime={self.end_datetime}>"

--- a/backend/src/model/alert.py
+++ b/backend/src/model/alert.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.db import Base

--- a/backend/src/model/analytics.py
+++ b/backend/src/model/analytics.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKeyConstraint, UniqueConstraint
+from sqlalchemy import ForeignKeyConstraint, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.db import Base

--- a/backend/src/model/analytics.py
+++ b/backend/src/model/analytics.py
@@ -2,7 +2,9 @@ from datetime import datetime
 
 from sqlalchemy import DateTime, ForeignKeyConstraint, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
+
 from src.db import Base
+from src.model.types import TZDateTime
 
 
 class Analytics(Base):
@@ -21,12 +23,12 @@ class Analytics(Base):
     exited: Mapped[int] = mapped_column(nullable=False)
     lat: Mapped[float] = mapped_column(nullable=False)
     lon: Mapped[float] = mapped_column(nullable=False)
-    datetime: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    datetime: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
 
     def __eq__(self, __value: object) -> bool:
+        # Exclude ID since it'll always differ, only compare on content
         return (
             isinstance(__value, Analytics)
-            and self.id == __value.id
             and self.van_id == __value.van_id
             and self.route_id == __value.route_id
             and self.entered == __value.entered
@@ -35,3 +37,6 @@ class Analytics(Base):
             and self.lon == __value.lon
             and self.datetime == __value.datetime
         )
+
+    def __repr__(self) -> str:
+        return f"<Analytics id={self.id} van_id={self.van_id} route_id={self.route_id} entered={self.entered} exited={self.exited} lat={self.lat} lon={self.lon} datetime={self.datetime}>"

--- a/backend/src/model/route.py
+++ b/backend/src/model/route.py
@@ -11,7 +11,6 @@ class Route(Base):
     )
     name: Mapped[str] = mapped_column(unique=True, nullable=False)
 
-    waypoints = relationship("Waypoint", backref="route", cascade="all, delete-orphan")
     def __eq__(self, __value: object) -> bool:
         # Exclude ID since it'll always differ, only compare on content
         return isinstance(__value, Route) and self.name == __value.name

--- a/backend/src/model/route.py
+++ b/backend/src/model/route.py
@@ -1,5 +1,6 @@
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+
 from src.db import Base
 from src.model.waypoint import Waypoint  # pylint: disable=unused-import
 

--- a/backend/src/model/route.py
+++ b/backend/src/model/route.py
@@ -1,7 +1,7 @@
 from sqlalchemy import UniqueConstraint
-from sqlalchemy.orm import Mapped, mapped_column
-
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from src.db import Base
+from src.model.waypoint import Waypoint  # pylint: disable=unused-import
 
 
 class Route(Base):
@@ -11,6 +11,8 @@ class Route(Base):
         primary_key=True, autoincrement=True, nullable=False
     )
     name: Mapped[str] = mapped_column(unique=True, nullable=False)
+
+    waypoints = relationship("Waypoint", backref="route", cascade="all, delete-orphan")
 
     def __eq__(self, __value: object) -> bool:
         # Exclude ID since it'll always differ, only compare on content

--- a/backend/src/model/route.py
+++ b/backend/src/model/route.py
@@ -1,5 +1,5 @@
 from sqlalchemy import UniqueConstraint
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from src.db import Base
 

--- a/backend/src/model/route.py
+++ b/backend/src/model/route.py
@@ -12,3 +12,9 @@ class Route(Base):
     name: Mapped[str] = mapped_column(unique=True, nullable=False)
 
     waypoints = relationship("Waypoint", backref="route", cascade="all, delete-orphan")
+    def __eq__(self, __value: object) -> bool:
+        # Exclude ID since it'll always differ, only compare on content
+        return isinstance(__value, Route) and self.name == __value.name
+
+    def __repr__(self) -> str:
+        return f"<Route id={self.id} name={self.name}>"

--- a/backend/src/model/route.py
+++ b/backend/src/model/route.py
@@ -1,5 +1,6 @@
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+
 from src.db import Base
 
 

--- a/backend/src/model/route_disable.py
+++ b/backend/src/model/route_disable.py
@@ -1,5 +1,6 @@
 from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy.orm import Mapped, mapped_column
+
 from src.db import Base
 
 
@@ -14,3 +15,14 @@ class RouteDisable(Base):
     )
     alert_id: Mapped[int] = mapped_column(nullable=False)
     route_id: Mapped[int] = mapped_column(nullable=False)
+
+    def __eq__(self, __value: object) -> bool:
+        # Exclude ID since it'll always differ, only compare on content
+        return (
+            isinstance(__value, RouteDisable)
+            and self.alert_id == __value.alert_id
+            and self.route_id == __value.route_id
+        )
+
+    def __repr__(self) -> str:
+        return f"<RouteDisable id={self.id} alert_id={self.alert_id} route_id={self.route_id}>"

--- a/backend/src/model/route_stop.py
+++ b/backend/src/model/route_stop.py
@@ -1,5 +1,6 @@
 from sqlalchemy import ForeignKeyConstraint, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
+
 from src.db import Base
 
 
@@ -15,3 +16,16 @@ class RouteStop(Base):
     )
     route_id: Mapped[int] = mapped_column(nullable=False)
     stop_id: Mapped[int] = mapped_column(nullable=False)
+
+    def __eq__(self, __value: object) -> bool:
+        # Exclude ID since it'll always differ, only compare on content
+        return (
+            isinstance(__value, RouteStop)
+            and self.route_id == __value.route_id
+            and self.stop_id == __value.stop_id
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"<RouteStop id={self.id} route_id={self.route_id} stop_id={self.stop_id}>"
+        )

--- a/backend/src/model/schedule.py
+++ b/backend/src/model/schedule.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKeyConstraint, UniqueConstraint
+from sqlalchemy import ForeignKeyConstraint, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.db import Base

--- a/backend/src/model/schedule.py
+++ b/backend/src/model/schedule.py
@@ -2,7 +2,9 @@ from datetime import datetime
 
 from sqlalchemy import DateTime, ForeignKeyConstraint, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
+
 from src.db import Base
+from src.model.types import TZDateTime
 
 
 class Schedule(Base):
@@ -16,5 +18,18 @@ class Schedule(Base):
     )
     route_id: Mapped[int] = mapped_column(nullable=False)
     dow: Mapped[int] = mapped_column(nullable=False)
-    start_time: Mapped[datetime] = mapped_column(DateTime, nullable=False)
-    end_time: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    start_time: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
+    end_time: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
+
+    def __eq__(self, __value: object) -> bool:
+        # Exclude ID since it'll always differ, only compare on content
+        return (
+            isinstance(__value, Schedule)
+            and self.route_id == __value.route_id
+            and self.dow == __value.dow
+            and self.start_time == __value.start_time
+            and self.end_time == __value.end_time
+        )
+
+    def __repr__(self) -> str:
+        return f"<Schedule id={self.id} route_id={self.route_id} dow={self.dow} start_time={self.start_time} end_time={self.end_time}>"

--- a/backend/src/model/stop.py
+++ b/backend/src/model/stop.py
@@ -1,5 +1,6 @@
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
+
 from src.db import Base
 
 
@@ -13,3 +14,16 @@ class Stop(Base):
     lat: Mapped[float] = mapped_column(nullable=False)
     lon: Mapped[float] = mapped_column(nullable=False)
     active: Mapped[bool] = mapped_column(nullable=False)
+
+    def __eq__(self, __value: object) -> bool:
+        # Exclude ID since it'll always differ, only compare on content
+        return (
+            isinstance(__value, Stop)
+            and self.name == __value.name
+            and self.lat == __value.lat
+            and self.lon == __value.lon
+            and self.active == __value.active
+        )
+
+    def __repr__(self) -> str:
+        return f"<Stop id={self.id} name={self.name} lat={self.lat} lon={self.lon} active={self.active}>"

--- a/backend/src/model/stop_disable.py
+++ b/backend/src/model/stop_disable.py
@@ -1,5 +1,6 @@
 from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy.orm import Mapped, mapped_column
+
 from src.db import Base
 
 
@@ -14,3 +15,14 @@ class StopDisable(Base):
     )
     alert_id: Mapped[int] = mapped_column(nullable=False)
     stop_id: Mapped[int] = mapped_column(nullable=False)
+
+    def __eq__(self, __value: object) -> bool:
+        # Exclude ID since it'll always differ, only compare on content
+        return (
+            isinstance(__value, StopDisable)
+            and self.alert_id == __value.alert_id
+            and self.stop_id == __value.stop_id
+        )
+
+    def __repr__(self) -> str:
+        return f"<StopDisable id={self.id} alert_id={self.alert_id} stop_id={self.stop_id}>"

--- a/backend/src/model/types.py
+++ b/backend/src/model/types.py
@@ -1,0 +1,23 @@
+import datetime
+
+from sqlalchemy import DateTime, TypeDecorator
+
+
+class TZDateTime(TypeDecorator):
+    impl = DateTime
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is not None:
+            if (
+                not value.tzinfo
+                or value.tzinfo.utcoffset(value) is None
+                or value.tzinfo != datetime.timezone.utc
+            ):
+                raise TypeError(f"tzinfo must be UTC, instead got {value.tzinfo}")
+        return value
+
+    def process_result_value(self, value, dialect):
+        if value is not None:
+            value = value.replace(tzinfo=datetime.timezone.utc)
+        return value

--- a/backend/src/model/van.py
+++ b/backend/src/model/van.py
@@ -1,5 +1,6 @@
 from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy.orm import Mapped, mapped_column
+
 from src.db import Base
 
 
@@ -11,3 +12,16 @@ class Van(Base):
     )
     route_id: Mapped[int] = mapped_column(nullable=False)
     wheelchair: Mapped[bool] = mapped_column(nullable=False)
+
+    def __eq__(self, __value: object) -> bool:
+        # Exclude ID since it'll always differ, only compare on content
+        return (
+            isinstance(__value, Van)
+            and self.route_id == __value.route_id
+            and self.wheelchair == __value.wheelchair
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"<Van id={self.id} route_id={self.route_id} wheelchair={self.wheelchair}>"
+        )

--- a/backend/src/model/waypoint.py
+++ b/backend/src/model/waypoint.py
@@ -1,5 +1,6 @@
 from sqlalchemy import ForeignKeyConstraint, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
+
 from src.db import Base
 
 
@@ -15,3 +16,15 @@ class Waypoint(Base):
     route_id: Mapped[int] = mapped_column(nullable=False)
     lat: Mapped[float] = mapped_column(nullable=False)
     lon: Mapped[float] = mapped_column(nullable=False)
+
+    def __eq__(self, __value: object) -> bool:
+        # Exclude ID since it'll always differ, only compare on content
+        return (
+            isinstance(__value, Waypoint)
+            and self.route_id == __value.route_id
+            and self.lat == __value.lat
+            and self.lon == __value.lon
+        )
+
+    def __repr__(self) -> str:
+        return f"<Waypoint id={self.id} route_id={self.route_id} lat={self.lat} lon={self.lon}>"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.db import Base
+
+
+class MockRouteArgs:
+    def __init__(
+        self,
+        req,
+        session,
+    ) -> None:
+        self.req = req
+        self.session = session
+
+
+@pytest.fixture
+def mock_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+@pytest.fixture
+def mock_route_args(mock_session) -> MockRouteArgs:
+    mock_req = MagicMock()
+    mock_req.app.state.db.session.return_value = mock_session
+    return MockRouteArgs(session=mock_session, req=mock_req)
+
+
+@pytest.fixture
+def mock_datetime():
+    return datetime.fromtimestamp(1691623800, timezone.utc)

--- a/backend/tests/test_alert.py
+++ b/backend/tests/test_alert.py
@@ -79,7 +79,7 @@ def test_get_alert(mock_route_args, mock_alerts):
 
     # Assert
     assert response == {
-        "id": mock_alert.id,
+        "id": 1,
         "text": "Alert 1",
         "startDateTime": int(mock_alerts[0].start_datetime.timestamp()),
         "endDateTime": int(mock_alerts[0].end_datetime.timestamp()),
@@ -115,7 +115,7 @@ def test_update_alert(mock_route_args, mock_alert):
         end_datetime=mock_alert.end_datetime + timedelta(minutes=2),
     )
     new_alert_model = AlertModel(
-        text=new_mock_alert.text,
+        text="New Alert (updated)",
         start_time=int(new_mock_alert.start_datetime.timestamp()),
         end_time=int(new_mock_alert.end_datetime.timestamp()),
     )

--- a/backend/tests/test_alert.py
+++ b/backend/tests/test_alert.py
@@ -1,0 +1,141 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.handlers.alert import (
+    AlertModel,
+    delete_alert,
+    get_alert,
+    get_alerts,
+    post_alert,
+    update_alert,
+)
+from src.model.alert import Alert
+
+
+@pytest.fixture
+def mock_alert():
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    return Alert(
+        id=1,
+        text="New Alert",
+        start_datetime=now,
+        end_datetime=now + timedelta(minutes=4),
+    )
+
+
+@pytest.fixture
+def mock_alerts():
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    alerts = [
+        Alert(
+            id=1,
+            text="Alert 1",
+            start_datetime=now,
+            end_datetime=now + timedelta(minutes=1),
+        ),
+        Alert(
+            id=2,
+            text="Alert 2",
+            start_datetime=now + timedelta(minutes=3),
+            end_datetime=now + timedelta(minutes=6),
+        ),
+    ]
+    return alerts
+
+
+def new_mock_req(session):
+    req = MagicMock()
+    req.app.state.db.session.return_value = session
+    return req
+
+
+def test_get_alerts(mock_route_args, mock_alerts):
+    mock_route_args.session.add_all(mock_alerts)
+    mock_route_args.session.commit()
+
+    # Act
+    response = get_alerts(mock_route_args.req)
+
+    # Assert
+    assert response == [
+        {
+            "text": mock_alert.text,
+            "startDateTime": int(mock_alert.start_datetime.timestamp()),
+            "endDateTime": int(mock_alert.end_datetime.timestamp()),
+        }
+        for mock_alert in mock_alerts
+    ]
+
+
+def test_get_alert(mock_route_args, mock_alerts):
+    mock_route_args.session.add_all(mock_alerts)
+    mock_route_args.session.commit()
+
+    # Act
+    response = get_alert(mock_route_args.req, 1)
+
+    # Assert
+    assert response == {
+        "text": "Alert 1",
+        "startDateTime": int(mock_alerts[0].start_datetime.timestamp()),
+        "endDateTime": int(mock_alerts[0].end_datetime.timestamp()),
+    }
+
+
+def test_post_alert(mock_route_args, mock_alert):
+    # Arrange
+    alert_model = AlertModel(
+        text=mock_alert.text,
+        start_time=int(mock_alert.start_datetime.timestamp()),
+        end_time=int(mock_alert.end_datetime.timestamp()),
+    )
+
+    # Act
+    response = post_alert(mock_route_args.req, alert_model)
+
+    # Assert
+    assert response == {"message": "OK"}
+    assert (
+        mock_route_args.session.query(Alert).filter_by(id=mock_alert.id).first()
+        == mock_alert
+    )
+
+
+def test_update_alert(mock_route_args, mock_alert):
+    # Arrange
+    mock_route_args.session.add(mock_alert)
+    new_mock_alert = Alert(
+        id=mock_alert.id,
+        text=mock_alert.text + " (updated)",
+        start_datetime=mock_alert.start_datetime + timedelta(minutes=1),
+        end_datetime=mock_alert.end_datetime + timedelta(minutes=2),
+    )
+    new_alert_model = AlertModel(
+        text=new_mock_alert.text,
+        start_time=int(new_mock_alert.start_datetime.timestamp()),
+        end_time=int(new_mock_alert.end_datetime.timestamp()),
+    )
+
+    # Act
+    response = update_alert(mock_route_args.req, mock_alert.id, new_alert_model)
+
+    # Assert
+    assert response == {"message": "OK"}
+    assert (
+        mock_route_args.session.query(Alert).filter_by(id=new_mock_alert.id).first()
+        == new_mock_alert
+    )
+
+
+def test_delete_alert(mock_route_args, mock_alert):
+    # Arrange
+    mock_route_args.session.add(mock_alert)
+
+    # Act
+    response = delete_alert(mock_route_args.req, mock_alert.id)
+
+    # Assert
+    assert response == {"message": "OK"}
+    assert mock_route_args.session.query(Alert).filter_by(id=mock_alert.id).count() == 0

--- a/backend/tests/test_alert.py
+++ b/backend/tests/test_alert.py
@@ -61,6 +61,7 @@ def test_get_alerts(mock_route_args, mock_alerts):
     # Assert
     assert response == [
         {
+            "id": mock_alert.id,
             "text": mock_alert.text,
             "startDateTime": int(mock_alert.start_datetime.timestamp()),
             "endDateTime": int(mock_alert.end_datetime.timestamp()),
@@ -78,6 +79,7 @@ def test_get_alert(mock_route_args, mock_alerts):
 
     # Assert
     assert response == {
+        "id": mock_alert.id,
         "text": "Alert 1",
         "startDateTime": int(mock_alerts[0].start_datetime.timestamp()),
         "endDateTime": int(mock_alerts[0].end_datetime.timestamp()),

--- a/backend/tests/test_ridership.py
+++ b/backend/tests/test_ridership.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from src.handlers.ridership import post_ridership_stats
+from src.handlers.ridership import post_ridership_stats, get_ridership, RidershipFilterModel
 from src.hardware import HardwareErrorCode, HardwareHTTPException, HardwareOKResponse
 from src.model.analytics import Analytics
 from src.model.route import Route
@@ -173,3 +173,40 @@ async def test_post_ridership_stats_not_most_recent(mock_route_args, mock_van_mo
     assert e.value.status_code == 400
     assert e.value.error_code == HardwareErrorCode.TIMESTAMP_NOT_MOST_RECENT
     assert mock_route_args.session.query(Analytics).filter_by(datetime=now).count() == 0
+
+@pytest.mark.parametrize(
+    "filter_params, expected_count",
+    [
+        (RidershipFilterModel(route_id=None, van_id=None, start_timestamp=None, end_timestamp=None), 10),  # No filters, expect all records
+        (RidershipFilterModel(route_id=1, van_id=None, start_timestamp=None, end_timestamp=None), 5),  # Filter by route_id
+        (RidershipFilterModel(route_id=None, van_id=1, start_timestamp=None, end_timestamp=None), 5),  # Filter by van_id
+        (RidershipFilterModel(route_id=None, van_id=None, start_timestamp=int(datetime(2022, 1, 1).timestamp()), end_timestamp=None), 10),  # Filter by start_date
+        (RidershipFilterModel(route_id=None, van_id=None, start_timestamp=None, end_timestamp=int(datetime(2022, 1, 6).timestamp())), 10),  # Filter by end_date
+        (
+            RidershipFilterModel(route_id=1, van_id=1, start_timestamp=int(datetime(2022, 1, 1).timestamp()), end_timestamp=int(datetime(2022, 1, 6).timestamp())),
+            5,
+        ),  # Filter by all parameters
+        (RidershipFilterModel(route_id=99, van_id=None, start_timestamp=None, end_timestamp=None), 0),  # Filter by non-existent route_id
+        (RidershipFilterModel(route_id=None, van_id=99, start_timestamp=None, end_timestamp=None), 0),  # Filter by non-existent van_id
+        (RidershipFilterModel(route_id=None, van_id=None, start_timestamp=int(datetime(2023, 1, 1).timestamp()), end_timestamp=None), 0),  # Filter by future start_date
+        (RidershipFilterModel(route_id=None, van_id=None, start_timestamp=None, end_timestamp=int(datetime(2021, 1, 1).timestamp())), 0),  # Filter by past end_date
+    ],
+)
+def test_get_ridership(mock_route_args, filter_params, expected_count):
+    # Arrange
+    mock_route_args.session.add_all([
+        Analytics(van_id=1, route_id=1, entered=1, exited=1, lat=37.7749, lon=-122.4194, datetime=datetime(2022, 1, 2, tzinfo=timezone.utc)),
+        Analytics(van_id=1, route_id=1, entered=1, exited=1, lat=37.7749, lon=-122.4194, datetime=datetime(2022, 1, 3, tzinfo=timezone.utc)),
+        Analytics(van_id=1, route_id=1, entered=1, exited=1, lat=37.7749, lon=-122.4194, datetime=datetime(2022, 1, 4, tzinfo=timezone.utc)),
+        Analytics(van_id=1, route_id=1, entered=1, exited=1, lat=37.7749, lon=-122.4194, datetime=datetime(2022, 1, 5, tzinfo=timezone.utc)),
+        Analytics(van_id=1, route_id=1, entered=1, exited=1, lat=37.7749, lon=-122.4194, datetime=datetime(2022, 1, 6, tzinfo=timezone.utc)),
+        Analytics(van_id=2, route_id=2, entered=1, exited=1, lat=37.7749, lon=-122.4194, datetime=datetime(2022, 1, 2, tzinfo=timezone.utc)),
+        Analytics(van_id=2, route_id=2, entered=1, exited=1, lat=37.7749, lon=-122.4194, datetime=datetime(2022, 1, 3, tzinfo=timezone.utc)),
+        Analytics(van_id=2, route_id=2, entered=1, exited=1, lat=37.7749, lon=-122.4194, datetime=datetime(2022, 1, 4, tzinfo=timezone.utc)),
+        Analytics(van_id=2, route_id=2, entered=1, exited=1, lat=37.7749, lon=-122.4194, datetime=datetime(2022, 1, 5, tzinfo=timezone.utc)),
+        Analytics(van_id=2, route_id=2, entered=1, exited=1, lat=37.7749, lon=-122.4194, datetime=datetime(2022, 1, 6, tzinfo=timezone.utc)),
+    ])
+    mock_route_args.session.commit()
+
+    response = get_ridership(mock_route_args.req, filter_params)
+    assert len(response) == expected_count

--- a/backend/tests/test_ridership.py
+++ b/backend/tests/test_ridership.py
@@ -3,18 +3,12 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
+
 from src.handlers.ridership import post_ridership_stats
 from src.hardware import HardwareErrorCode, HardwareHTTPException, HardwareOKResponse
 from src.model.analytics import Analytics
+from src.model.route import Route
 from src.model.van import Van
-
-
-@pytest.fixture
-def mock_session():
-    mock = MagicMock()
-    mock.__enter__.return_value = mock
-    mock.__exit__.return_value = False
-    return mock
 
 
 @pytest.fixture
@@ -34,170 +28,148 @@ def new_mock_ridership(time: datetime):
     )
 
 
-def new_mock_req(time: datetime, ridership: MagicMock, session: MagicMock):
-    async def mock_body():
+def mock_analytics_body(analytics: Analytics, time: datetime):
+    async def inner():
         return struct.pack(
             "!lbbdd",
             int(time.timestamp()),
-            ridership.entered,
-            ridership.exited,
-            ridership.lat,
-            ridership.lon,
+            analytics.entered,
+            analytics.exited,
+            analytics.lat,
+            analytics.lon,
         )
 
-    req = MagicMock()
-    req.body = mock_body
-    req.app.state.db.session.return_value = session
-    return req
-
-
-def new_route_side_effect(van_model, ridership):
-    def route_side_effect(*args):
-        # Create different mock query objects for each model
-        if args[0] is Van:
-            mock_query = MagicMock()
-            mock_query.filter_by.return_value.first.return_value = van_model
-            return mock_query
-
-        if args[0] is Analytics:
-            mock_query = MagicMock()
-            mock_query.filter_by.return_value.order_by.return_value.first.return_value = (
-                ridership
-            )
-            return mock_query
-
-        raise TypeError("Invalid model type")
-
-    return route_side_effect
+    return inner
 
 
 @pytest.mark.asyncio
-async def test_post_ridership_stats_with_prior(mock_session, mock_van_model):
+async def test_post_ridership_stats_with_prior(mock_route_args, mock_van_model):
     # Arrange
     now = datetime.now(timezone.utc).replace(microsecond=0)
-    new_ridership = new_mock_ridership(now)
-    req = new_mock_req(now, new_ridership, mock_session)
     prior_ridership = new_mock_ridership(now - timedelta(minutes=1))
-    mock_session.query.side_effect = new_route_side_effect(
-        mock_van_model, prior_ridership
-    )
+    new_ridership = new_mock_ridership(now)
+    mock_route_args.req.body = mock_analytics_body(new_ridership, now)
+    mock_route_args.session.add(mock_van_model)
+    mock_route_args.session.add(prior_ridership)
+    mock_route_args.session.commit()
 
     # Act
-    response = await post_ridership_stats(req, mock_van_model.id)
+    response = await post_ridership_stats(mock_route_args.req, mock_van_model.id)
 
     # Assert
     assert response == HardwareOKResponse()
-    mock_session.add.assert_called_once_with(new_ridership)
-    mock_session.commit.assert_called_once()
+    assert mock_route_args.session.query(Analytics).filter_by(datetime=now).count() > 0
 
 
 @pytest.mark.asyncio
-async def test_post_ridership_stats_without_prior(mock_session, mock_van_model):
+async def test_post_ridership_stats_without_prior(mock_route_args, mock_van_model):
     # Arrange
     now = datetime.now(timezone.utc).replace(microsecond=0)
     new_ridership = new_mock_ridership(now)
-    req = new_mock_req(now, new_ridership, mock_session)
-    mock_session.query.side_effect = new_route_side_effect(mock_van_model, None)
+    mock_route_args.req.body = mock_analytics_body(new_ridership, now)
+    mock_route_args.session.add(mock_van_model)
+    mock_route_args.session.commit()
 
     # Act
-    response = await post_ridership_stats(req, mock_van_model.id)
+    response = await post_ridership_stats(mock_route_args.req, mock_van_model.id)
 
     # Assert
     assert response == HardwareOKResponse()
-    mock_session.add.assert_called_once_with(new_ridership)
-    mock_session.commit.assert_called_once()
+    assert mock_route_args.session.query(Analytics).filter_by(datetime=now).count() > 0
 
 
 @pytest.mark.asyncio
-async def test_post_ridership_stats_too_far_in_past(mock_session, mock_van_model):
+async def test_post_ridership_stats_too_far_in_past(mock_route_args, mock_van_model):
     # Arrange
     now = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(minutes=2)
     new_ridership = new_mock_ridership(now)
-    req = new_mock_req(now, new_ridership, mock_session)
-    mock_session.query.side_effect = new_route_side_effect(mock_van_model, None)
+    mock_route_args.req.body = mock_analytics_body(new_ridership, now)
+    mock_route_args.session.add(mock_van_model)
+    mock_route_args.session.commit()
 
     # Act
     with pytest.raises(HardwareHTTPException) as e:
-        await post_ridership_stats(req, mock_van_model.id)
+        await post_ridership_stats(mock_route_args.req, mock_van_model.id)
 
     # Assert
     assert e.value.status_code == 400
     assert e.value.error_code == HardwareErrorCode.TIMESTAMP_TOO_FAR_IN_PAST
-    mock_session.add.not_assert_called_once_with(new_ridership)
+    assert mock_route_args.session.query(Analytics).filter_by(datetime=now).count() == 0
 
 
 @pytest.mark.asyncio
-async def test_post_ridership_stats_in_future(mock_session, mock_van_model):
+async def test_post_ridership_stats_in_future(mock_route_args, mock_van_model):
     # Arrange
     now = datetime.now(timezone.utc).replace(microsecond=0) + timedelta(minutes=2)
     new_ridership = new_mock_ridership(now)
-    req = new_mock_req(now, new_ridership, mock_session)
-    mock_session.query.side_effect = new_route_side_effect(mock_van_model, None)
+    mock_route_args.req.body = mock_analytics_body(new_ridership, now)
+    mock_route_args.session.add(mock_van_model)
+    mock_route_args.session.commit()
 
     # Act
     with pytest.raises(HardwareHTTPException) as e:
-        await post_ridership_stats(req, mock_van_model.id)
+        await post_ridership_stats(mock_route_args.req, mock_van_model.id)
 
     # Assert
     assert e.value.status_code == 400
     assert e.value.error_code == HardwareErrorCode.TIMESTAMP_IN_FUTURE
-    mock_session.add.not_assert_called_once_with(new_ridership)
+    assert mock_route_args.session.query(Analytics).filter_by(datetime=now).count() == 0
 
 
 @pytest.mark.asyncio
 async def test_post_ridership_van_not_active_invalid_param(
-    mock_session, mock_van_model
+    mock_route_args, mock_van_model
 ):
     # Arrange
     now = datetime.now(timezone.utc).replace(microsecond=0)
     new_ridership = new_mock_ridership(now)
-    req = new_mock_req(now, new_ridership, mock_session)
-    mock_session.query.side_effect = new_route_side_effect(None, mock_van_model)
+    mock_route_args.req.body = mock_analytics_body(new_ridership, now)
+    mock_route_args.session.add(mock_van_model)
+    mock_route_args.session.commit()
 
     # Act
     with pytest.raises(HardwareHTTPException) as e:
-        await post_ridership_stats(req, 16)
+        await post_ridership_stats(mock_route_args.req, 16)
 
     # Assert
     assert e.value.status_code == 404
     assert e.value.error_code == HardwareErrorCode.VAN_NOT_ACTIVE
-    mock_session.add.not_assert_called_once_with(new_ridership)
+    assert mock_route_args.session.query(Analytics).filter_by(datetime=now).count() == 0
 
 
 @pytest.mark.asyncio
-async def test_post_ridership_van_not_active_valid_param(mock_session):
+async def test_post_ridership_van_not_active_valid_param(mock_route_args):
     # Arrange
     now = datetime.now(timezone.utc).replace(microsecond=0)
     new_ridership = new_mock_ridership(now)
-    req = new_mock_req(now, new_ridership, mock_session)
-    mock_session.query.side_effect = new_route_side_effect(None, None)
+    mock_route_args.req.body = mock_analytics_body(new_ridership, now)
 
     # Act
     with pytest.raises(HardwareHTTPException) as e:
-        await post_ridership_stats(req, 1)
+        await post_ridership_stats(mock_route_args.req, 1)
 
     # Assert
     assert e.value.status_code == 404
     assert e.value.error_code == HardwareErrorCode.VAN_NOT_ACTIVE
-    mock_session.add.not_assert_called_once_with(new_ridership)
+    assert mock_route_args.session.query(Analytics).filter_by(datetime=now).count() == 0
 
 
 @pytest.mark.asyncio
-async def test_post_ridership_stats_not_most_recent(mock_session, mock_van_model):
+async def test_post_ridership_stats_not_most_recent(mock_route_args, mock_van_model):
     # Arrange
     now = datetime.now(timezone.utc).replace(microsecond=0)
     new_ridership = new_mock_ridership(now)
-    req = new_mock_req(now, new_ridership, mock_session)
     prior_ridership = new_mock_ridership(now + timedelta(minutes=1))
-    mock_session.query.side_effect = new_route_side_effect(
-        mock_van_model, prior_ridership
-    )
+    mock_route_args.req.body = mock_analytics_body(new_ridership, now)
+    mock_route_args.session.add(mock_van_model)
+    mock_route_args.session.add(prior_ridership)
+    mock_route_args.session.commit()
 
     # Act
     with pytest.raises(HardwareHTTPException) as e:
-        await post_ridership_stats(req, mock_van_model.id)
+        await post_ridership_stats(mock_route_args.req, mock_van_model.id)
 
     # Assert
     assert e.value.status_code == 400
     assert e.value.error_code == HardwareErrorCode.TIMESTAMP_NOT_MOST_RECENT
-    mock_session.add.not_assert_called_once_with(new_ridership)
+    assert mock_route_args.session.query(Analytics).filter_by(datetime=now).count() == 0

--- a/backend/tests/test_stops.py
+++ b/backend/tests/test_stops.py
@@ -1,20 +1,14 @@
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
 
-from src.handlers.stops import (
-    StopModel,
-    get_stops,
-    get_stop,
-    create_stop,
-    update_stop,
-)
-from src.model.stop import Stop
+from src.handlers.stops import StopModel, create_stop, get_stop, get_stops, update_stop
+from src.model.alert import Alert
 from src.model.route import Route
 from src.model.route_stop import RouteStop
+from src.model.stop import Stop
 from src.model.stop_disable import StopDisable
-from src.model.alert import Alert
 
 
 @pytest.fixture

--- a/backend/tests/test_stops.py
+++ b/backend/tests/test_stops.py
@@ -1,0 +1,443 @@
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.handlers.stops import (
+    StopModel,
+    get_stops,
+    get_stop,
+    create_stop,
+    update_stop,
+)
+from src.model.stop import Stop
+from src.model.route import Route
+from src.model.route_stop import RouteStop
+from src.model.stop_disable import StopDisable
+from src.model.alert import Alert
+
+
+@pytest.fixture
+def mock_stop():
+    return Stop(
+        id=1,
+        name="Stop 1",
+        lat=52.5200,
+        lon=13.4050,
+        active=True,
+    )
+
+
+@pytest.fixture
+def mock_stops():
+    return [
+        Stop(
+            id=1,
+            name="Stop 1",
+            lat=52.5200,
+            lon=13.4050,
+            active=True,
+        ),
+        Stop(
+            id=2,
+            name="Stop 2",
+            lat=48.8566,
+            lon=2.3522,
+            active=False,
+        ),
+        Stop(
+            id=3,
+            name="Stop 3",
+            lat=51.5074,
+            lon=0.1278,
+            active=True,
+        ),
+    ]
+
+
+@pytest.fixture
+def mock_routes():
+    return [
+        Route(id=1, name="Route 1"),
+        Route(id=2, name="Route 2"),
+    ]
+
+
+@pytest.fixture
+def mock_route_stops():
+    return [
+        RouteStop(id=1, route_id=1, stop_id=1),
+        RouteStop(id=2, route_id=2, stop_id=2),
+        RouteStop(id=3, route_id=1, stop_id=2),
+        RouteStop(id=4, route_id=1, stop_id=3),
+    ]
+
+
+@pytest.fixture
+def mock_alert():
+    return Alert(
+        id=1,
+        text="Alert 1",
+        start_datetime=datetime.now(timezone.utc),
+        end_datetime=datetime.now(timezone.utc) + timedelta(minutes=1),
+    )
+
+
+@pytest.fixture
+def mock_stop_disables():
+    return [StopDisable(id=1, stop_id=3, alert_id=1)]
+
+
+def test_get_stops_no_includes(mock_route_args, mock_stops):
+    mock_route_args.session.add_all(mock_stops)
+    mock_route_args.session.commit()
+
+    # Act
+    response = get_stops(mock_route_args.req)
+
+    # Assert
+    assert response == [
+        {
+            "id": mock_stop.id,
+            "name": mock_stop.name,
+            "latitude": mock_stop.lat,
+            "longitude": mock_stop.lon,
+        }
+        for mock_stop in mock_stops
+    ]
+
+
+def test_get_stops_include_routeIds(
+    mock_route_args, mock_stops, mock_routes, mock_route_stops
+):
+    mock_route_args.session.add_all(mock_stops)
+    mock_route_args.session.add_all(mock_routes)
+    mock_route_args.session.add_all(mock_route_stops)
+    mock_route_args.session.commit()
+
+    mock_stop_route_ids = {1: [1], 2: [2, 1], 3: [1]}
+
+    # Act
+    response = get_stops(mock_route_args.req, ["routeIds"])
+
+    # Assert
+    assert response == [
+        {
+            "id": mock_stop.id,
+            "name": mock_stop.name,
+            "latitude": mock_stop.lat,
+            "longitude": mock_stop.lon,
+            "routeIds": mock_stop_route_ids[mock_stop.id],
+        }
+        for mock_stop in mock_stops
+    ]
+
+
+def test_get_stops_include_is_active_no_alert(mock_route_args, mock_stops):
+    mock_route_args.session.add_all(mock_stops)
+    mock_route_args.session.commit()
+
+    mock_stop_is_active = {1: True, 2: False, 3: True}
+
+    # Act
+    response = get_stops(mock_route_args.req, ["isActive"])
+
+    # Assert
+    assert response == [
+        {
+            "id": mock_stop.id,
+            "name": mock_stop.name,
+            "latitude": mock_stop.lat,
+            "longitude": mock_stop.lon,
+            "isActive": mock_stop_is_active[mock_stop.id],
+        }
+        for mock_stop in mock_stops
+    ]
+
+
+def test_get_stops_include_is_active_with_alert(
+    mock_route_args, mock_stops, mock_alert
+):
+    mock_route_args.session.add_all(mock_stops)
+    mock_route_args.session.add(mock_alert)
+    mock_route_args.session.commit()
+
+    mock_stop_is_active = {1: True, 2: False, 3: True}
+
+    # Act
+    response = get_stops(mock_route_args.req, ["isActive"])
+
+    # Assert
+    assert response == [
+        {
+            "id": mock_stop.id,
+            "name": mock_stop.name,
+            "latitude": mock_stop.lat,
+            "longitude": mock_stop.lon,
+            "isActive": mock_stop_is_active[mock_stop.id],
+        }
+        for mock_stop in mock_stops
+    ]
+
+
+def test_get_stops_include_is_active_with_alert_and_disable(
+    mock_route_args, mock_stops, mock_alert, mock_stop_disables
+):
+    mock_route_args.session.add_all(mock_stops)
+    mock_route_args.session.add(mock_alert)
+    mock_route_args.session.add_all(mock_stop_disables)
+    mock_route_args.session.commit()
+
+    mock_stop_is_active = {1: True, 2: False, 3: False}
+
+    # Act
+    response = get_stops(mock_route_args.req, ["isActive"])
+
+    # Assert
+    assert response == [
+        {
+            "id": mock_stop.id,
+            "name": mock_stop.name,
+            "latitude": mock_stop.lat,
+            "longitude": mock_stop.lon,
+            "isActive": mock_stop_is_active[mock_stop.id],
+        }
+        for mock_stop in mock_stops
+    ]
+
+
+def test_get_stops_include_route_ids_and_is_active(
+    mock_route_args,
+    mock_stops,
+    mock_routes,
+    mock_route_stops,
+    mock_alert,
+    mock_stop_disables,
+):
+    mock_route_args.session.add_all(mock_stops)
+    mock_route_args.session.add_all(mock_routes)
+    mock_route_args.session.add_all(mock_route_stops)
+    mock_route_args.session.add(mock_alert)
+    mock_route_args.session.add_all(mock_stop_disables)
+    mock_route_args.session.commit()
+
+    mock_stop_route_ids = {1: [1], 2: [2, 1], 3: [1]}
+
+    mock_stop_is_active = {1: True, 2: False, 3: False}
+
+    # Act
+    response = get_stops(mock_route_args.req, ["routeIds", "isActive"])
+
+    # Assert
+    assert response == [
+        {
+            "id": mock_stop.id,
+            "name": mock_stop.name,
+            "latitude": mock_stop.lat,
+            "longitude": mock_stop.lon,
+            "routeIds": mock_stop_route_ids[mock_stop.id],
+            "isActive": mock_stop_is_active[mock_stop.id],
+        }
+        for mock_stop in mock_stops
+    ]
+
+
+def test_get_stop_no_includes(mock_route_args, mock_stops):
+    mock_route_args.session.add_all(mock_stops)
+    mock_route_args.session.commit()
+
+    mock_stop = mock_stops[0]
+
+    # Act
+    response = get_stop(mock_route_args.req, mock_stop.id)
+
+    # Assert
+    assert response == {
+        "id": mock_stop.id,
+        "name": mock_stop.name,
+        "latitude": mock_stop.lat,
+        "longitude": mock_stop.lon,
+    }
+
+
+def test_get_stop_include_is_active_and_active(mock_route_args, mock_stops):
+    mock_route_args.session.add_all(mock_stops)
+    mock_route_args.session.commit()
+
+    mock_stop = mock_stops[0]
+
+    # Act
+    response = get_stop(mock_route_args.req, mock_stop.id, ["isActive"])
+
+    # Assert
+    assert response == {
+        "id": mock_stop.id,
+        "name": mock_stop.name,
+        "latitude": mock_stop.lat,
+        "longitude": mock_stop.lon,
+        "isActive": mock_stop.active,
+    }
+
+
+def test_get_stop_include_is_active_and_inactive(mock_route_args, mock_stops):
+    mock_route_args.session.add_all(mock_stops)
+    mock_route_args.session.commit()
+
+    mock_stop = mock_stops[1]
+
+    # Act
+    response = get_stop(mock_route_args.req, mock_stop.id, ["isActive"])
+
+    # Assert
+    assert response == {
+        "id": mock_stop.id,
+        "name": mock_stop.name,
+        "latitude": mock_stop.lat,
+        "longitude": mock_stop.lon,
+        "isActive": mock_stop.active,
+    }
+
+
+def test_get_stop_include_is_active_with_alert(mock_route_args, mock_stops, mock_alert):
+    mock_route_args.session.add_all(mock_stops)
+    mock_route_args.session.add(mock_alert)
+    mock_route_args.session.commit()
+
+    mock_stop = mock_stops[2]
+
+    # Act
+    response = get_stop(mock_route_args.req, mock_stop.id, ["isActive"])
+
+    # Assert
+    assert response == {
+        "id": mock_stop.id,
+        "name": mock_stop.name,
+        "latitude": mock_stop.lat,
+        "longitude": mock_stop.lon,
+        "isActive": mock_stop.active,
+    }
+
+
+def test_get_stop_include_is_active_with_alert_and_disables(
+    mock_route_args, mock_stops, mock_alert, mock_stop_disables
+):
+    mock_route_args.session.add_all(mock_stops)
+    mock_route_args.session.add(mock_alert)
+    mock_route_args.session.add_all(mock_stop_disables)
+    mock_route_args.session.commit()
+
+    mock_stop = mock_stops[2]
+
+    # Act
+    response = get_stop(mock_route_args.req, mock_stop.id, ["isActive"])
+
+    # Assert
+    assert response == {
+        "id": mock_stop.id,
+        "name": mock_stop.name,
+        "latitude": mock_stop.lat,
+        "longitude": mock_stop.lon,
+        "isActive": False,
+    }
+
+
+def test_get_stop_with_route_ids(
+    mock_route_args, mock_stops, mock_routes, mock_route_stops
+):
+    mock_route_args.session.add_all(mock_stops)
+    mock_route_args.session.add_all(mock_routes)
+    mock_route_args.session.add_all(mock_route_stops)
+    mock_route_args.session.commit()
+
+    mock_stop = mock_stops[1]
+
+    # Act
+    response = get_stop(mock_route_args.req, mock_stop.id, ["routeIds"])
+
+    # Assert
+    assert response == {
+        "id": mock_stop.id,
+        "name": mock_stop.name,
+        "latitude": mock_stop.lat,
+        "longitude": mock_stop.lon,
+        "routeIds": [2, 1],
+    }
+
+
+def test_get_stop_with_routeIds_and_isActive(
+    mock_route_args,
+    mock_stops,
+    mock_routes,
+    mock_route_stops,
+    mock_alert,
+    mock_stop_disables,
+):
+    mock_route_args.session.add_all(mock_stops)
+    mock_route_args.session.add_all(mock_routes)
+    mock_route_args.session.add_all(mock_route_stops)
+    mock_route_args.session.add(mock_alert)
+    mock_route_args.session.add_all(mock_stop_disables)
+    mock_route_args.session.commit()
+
+    mock_stop = mock_stops[2]
+
+    # Act
+    response = get_stop(mock_route_args.req, mock_stop.id, ["routeIds", "isActive"])
+
+    # Assert
+    assert response == {
+        "id": mock_stop.id,
+        "name": mock_stop.name,
+        "latitude": mock_stop.lat,
+        "longitude": mock_stop.lon,
+        "routeIds": [1],
+        "isActive": False,
+    }
+
+
+def test_create_stop(mock_route_args, mock_stop):
+    # Arrange
+    stop_model = StopModel(
+        name=mock_stop.name,
+        latitude=mock_stop.lat,
+        longitude=mock_stop.lon,
+        active=mock_stop.active,
+    )
+
+    # Act
+    response = create_stop(mock_route_args.req, stop_model)
+
+    # Assert
+    assert response == {"message": "OK"}
+    assert (
+        mock_route_args.session.query(Stop).filter_by(id=mock_stop.id).first()
+        == mock_stop
+    )
+
+
+def test_update_stop(mock_route_args, mock_stop):
+    # Arrange
+    mock_route_args.session.add(mock_stop)
+    new_mock_stop = Stop(
+        id=mock_stop.id,
+        name=mock_stop.name + " (updated)",
+        lat=mock_stop.lat + 1,
+        lon=mock_stop.lon + 1,
+        active=not mock_stop.active,
+    )
+    new_stop_model = StopModel(
+        name=new_mock_stop.name,
+        latitude=new_mock_stop.lat,
+        longitude=new_mock_stop.lon,
+        active=new_mock_stop.active,
+    )
+
+    # Act
+    response = update_stop(mock_route_args.req, mock_stop.id, new_stop_model)
+
+    # Assert
+    assert response == {"message": "OK"}
+    assert (
+        mock_route_args.session.query(Stop).filter_by(id=new_mock_stop.id).first()
+        == new_mock_stop
+    )

--- a/backend/tests/test_stops.py
+++ b/backend/tests/test_stops.py
@@ -243,14 +243,14 @@ def test_get_stop_no_includes(mock_route_args, mock_stops):
     mock_stop = mock_stops[0]
 
     # Act
-    response = get_stop(mock_route_args.req, mock_stop.id)
+    response = get_stop(mock_route_args.req, 1)
 
     # Assert
     assert response == {
-        "id": mock_stop.id,
-        "name": mock_stop.name,
-        "latitude": mock_stop.lat,
-        "longitude": mock_stop.lon,
+        "id": 1,
+        "name": "Stop 1",
+        "latitude": 52.5200,
+        "longitude": 13.4050,
     }
 
 
@@ -261,15 +261,15 @@ def test_get_stop_include_is_active_and_active(mock_route_args, mock_stops):
     mock_stop = mock_stops[0]
 
     # Act
-    response = get_stop(mock_route_args.req, mock_stop.id, ["isActive"])
+    response = get_stop(mock_route_args.req, 1, ["isActive"])
 
     # Assert
     assert response == {
-        "id": mock_stop.id,
-        "name": mock_stop.name,
-        "latitude": mock_stop.lat,
-        "longitude": mock_stop.lon,
-        "isActive": mock_stop.active,
+        "id": 1,
+        "name": "Stop 1",
+        "latitude": 52.5200,
+        "longitude": 13.4050,
+        "isActive": True,
     }
 
 
@@ -277,18 +277,16 @@ def test_get_stop_include_is_active_and_inactive(mock_route_args, mock_stops):
     mock_route_args.session.add_all(mock_stops)
     mock_route_args.session.commit()
 
-    mock_stop = mock_stops[1]
-
     # Act
-    response = get_stop(mock_route_args.req, mock_stop.id, ["isActive"])
+    response = get_stop(mock_route_args.req, 2, ["isActive"])
 
     # Assert
     assert response == {
-        "id": mock_stop.id,
-        "name": mock_stop.name,
-        "latitude": mock_stop.lat,
-        "longitude": mock_stop.lon,
-        "isActive": mock_stop.active,
+        "id": 2,
+        "name": "Stop 2",
+        "latitude": 48.8566,
+        "longitude": 2.3522,
+        "isActive": False,
     }
 
 
@@ -300,15 +298,15 @@ def test_get_stop_include_is_active_with_alert(mock_route_args, mock_stops, mock
     mock_stop = mock_stops[2]
 
     # Act
-    response = get_stop(mock_route_args.req, mock_stop.id, ["isActive"])
+    response = get_stop(mock_route_args.req, 3, ["isActive"])
 
     # Assert
     assert response == {
-        "id": mock_stop.id,
-        "name": mock_stop.name,
-        "latitude": mock_stop.lat,
-        "longitude": mock_stop.lon,
-        "isActive": mock_stop.active,
+        "id": 3,
+        "name": "Stop 3",
+        "latitude": 51.5074,
+        "longitude": 0.1278,
+        "isActive": True,
     }
 
 
@@ -320,17 +318,15 @@ def test_get_stop_include_is_active_with_alert_and_disables(
     mock_route_args.session.add_all(mock_stop_disables)
     mock_route_args.session.commit()
 
-    mock_stop = mock_stops[2]
-
     # Act
-    response = get_stop(mock_route_args.req, mock_stop.id, ["isActive"])
+    response = get_stop(mock_route_args.req, 3, ["isActive"])
 
     # Assert
     assert response == {
-        "id": mock_stop.id,
-        "name": mock_stop.name,
-        "latitude": mock_stop.lat,
-        "longitude": mock_stop.lon,
+        "id": 3,
+        "name": "Stop 3",
+        "latitude": 51.5074,
+        "longitude": 0.1278,
         "isActive": False,
     }
 
@@ -343,17 +339,15 @@ def test_get_stop_with_route_ids(
     mock_route_args.session.add_all(mock_route_stops)
     mock_route_args.session.commit()
 
-    mock_stop = mock_stops[1]
-
     # Act
-    response = get_stop(mock_route_args.req, mock_stop.id, ["routeIds"])
+    response = get_stop(mock_route_args.req, 2, ["routeIds"])
 
     # Assert
     assert response == {
-        "id": mock_stop.id,
-        "name": mock_stop.name,
-        "latitude": mock_stop.lat,
-        "longitude": mock_stop.lon,
+        "id": 2,
+        "name": "Stop 2",
+        "latitude": 48.8566,
+        "longitude": 2.3522,
         "routeIds": [2, 1],
     }
 
@@ -373,17 +367,15 @@ def test_get_stop_with_routeIds_and_isActive(
     mock_route_args.session.add_all(mock_stop_disables)
     mock_route_args.session.commit()
 
-    mock_stop = mock_stops[2]
-
     # Act
-    response = get_stop(mock_route_args.req, mock_stop.id, ["routeIds", "isActive"])
+    response = get_stop(mock_route_args.req, 3, ["routeIds", "isActive"])
 
     # Assert
     assert response == {
-        "id": mock_stop.id,
-        "name": mock_stop.name,
-        "latitude": mock_stop.lat,
-        "longitude": mock_stop.lon,
+        "id": 3,
+        "name": "Stop 3",
+        "latitude": 51.5074,
+        "longitude": 0.1278,
         "routeIds": [1],
         "isActive": False,
     }


### PR DESCRIPTION
Add more and better tests to the CRUD routes that aren't likely to change very much (At least after #82). Will undraft as soon as #82 is merged, since it changes the alert code a bit.

- Use an in-memory mock database for testing. This is pretty quick and also allows us to make sure our queries are doing the right thing
- Add some equality and repr methods for the database models so I can confirm that no data is being mangled in transit.