### PR TITLE
Frontend: Fix map issues

### DIFF
--- a/frontend/src/features/map/Map.tsx
+++ b/frontend/src/features/map/Map.tsx
@@ -122,7 +122,7 @@ const Map: React.FC<MapProps> = ({ insets }) => {
                   styles.marker,
                   {
                     backgroundColor: Color.orecart.get(
-                      routesById[van.routeId].name,
+                      routesById[van.routeId]?.name,
                     ),
                   },
                 ]}
@@ -158,7 +158,7 @@ const Map: React.FC<MapProps> = ({ insets }) => {
                 styles.marker,
                 {
                   backgroundColor: Color.orecart.get(
-                    routesById[stop.routeIds[0]].name,
+                    routesById[stop.routeIds[0]]?.name,
                   ),
                 },
               ]}

--- a/frontend/src/features/map/Map.tsx
+++ b/frontend/src/features/map/Map.tsx
@@ -112,7 +112,7 @@ const Map: React.FC<MapProps> = ({ insets }) => {
         {vans?.map((van, index) =>
           van.location !== undefined ? (
             <Marker
-              key={index}
+              key={van.id}
               coordinate={van.location}
               tracksViewChanges={false}
               anchor={{ x: 0.5, y: 0.5 }}
@@ -138,7 +138,7 @@ const Map: React.FC<MapProps> = ({ insets }) => {
         )}
         {routes?.map((route, index) => (
           <Polyline
-            key={index}
+            key={route.id}
             coordinates={route.waypoints}
             strokeColor={Color.orecart.get(route.name)}
             strokeWidth={4}
@@ -148,7 +148,7 @@ const Map: React.FC<MapProps> = ({ insets }) => {
         ))}
         {stops?.map((stop, index) => (
           <Marker
-            key={vans?.length ?? 0 + index}
+            key={stop.id}
             coordinate={stop}
             tracksViewChanges={false}
             anchor={{ x: 0.5, y: 0.5 }}


### PR DESCRIPTION
- Correctly key map elements by their ID
- Avoid a crash when data loads out of order and stops/vans cannot reference their route colors. In practice this needs to be completely thrown out and replaced with an include param once #71 is worked on.