### PR TITLE
Byte order fix

### DIFF
--- a/backend/src/handlers/ridership.py
+++ b/backend/src/handlers/ridership.py
@@ -64,7 +64,7 @@ async def post_ridership_stats(req: Request, van_id: int):
     This route is used by the hardware components to send ridership statistics to be
     logged in the database. The body of the request is a packed byte array containing
     the following values in order:
-    - timestamp of time when response was sent (64-bit seconds since epoch)
+    - timestamp of time when response was sent (64-bit milliseconds since epoch)
     - entered (8-bit, number of people who entered the van at a given stop)
     - exited (8-bit, number of people who exited the van at the stop)
     - lat (double-precision float, current latitude of the van at the stop)
@@ -73,8 +73,8 @@ async def post_ridership_stats(req: Request, van_id: int):
 
     # Unpack the byte body sent by the hardware into their corresponding values
     body = await req.body()
-    timestamp, entered, exited, lat, lon = struct.unpack("!lbbdd", body)
-    timestamp = datetime.fromtimestamp(timestamp, timezone.utc)
+    timestamp_ms, entered, exited, lat, lon = struct.unpack("<Qbbdd", body)
+    timestamp = datetime.fromtimestamp(timestamp_ms / 1000.0, timezone.utc)
 
     current_time = datetime.now(timezone.utc)
 

--- a/backend/src/handlers/vans.py
+++ b/backend/src/handlers/vans.py
@@ -207,10 +207,10 @@ def get_location_for_van(
 
 @router.post("/location/{van_id}")
 async def post_location(req: Request, van_id: int) -> HardwareOKResponse:
-    # byte body: long for timestamp, double for lat, double for lon
+    # byte body: long long for timestamp, double for lat, double for lon
     body = await req.body()
-    timestamp, lat, lon = struct.unpack("!ldd", body)
-    timestamp = datetime.fromtimestamp(timestamp, timezone.utc)
+    timestamp_ms, lat, lon = struct.unpack("<Qdd", body)
+    timestamp = datetime.fromtimestamp(timestamp_ms / 1000.0, timezone.utc)
 
     current_time = datetime.now(timezone.utc)
 

--- a/backend/tests/test_ridership.py
+++ b/backend/tests/test_ridership.py
@@ -34,8 +34,8 @@ def new_mock_ridership(time: datetime):
 def mock_analytics_body(analytics: Analytics, time: datetime):
     async def inner():
         return struct.pack(
-            "!lbbdd",
-            int(time.timestamp()),
+            "<Qbbdd",
+            int(time.timestamp() * 1000),
             analytics.entered,
             analytics.exited,
             analytics.lat,


### PR DESCRIPTION
I think it makes more sense to have a Little Endian byte order for the struct so that the HW doesn't have to swap bytes, at least that's how it works right now.
It wouldn't be too much of a pain to invert the bytes, but it just feels unnecessary.

Unix typically stores timestamps as 32-bit integers, but the hardware sends them as 64 bits in milliseconds for future-proofing beyond 2038.
I used milliseconds because why not? If we're going to be sending 64-bit numbers, might as well not waste those extra bits.

This should be good until the year 584,944,387, at which point we will have to issue a patch. 