### PR TITLE
Backend: Convert raw sql in alembic to sqlalchemy

### DIFF
--- a/backend/alembic/README.md
+++ b/backend/alembic/README.md
@@ -28,9 +28,6 @@ Migrations should be created on all database changes using
 alembic revision -m "descriptive message here"
 ```
 
-This will generate a new file called something like "abcdef123456_descriptive_message_here.py". It will contain an "upgrade" method should take the
-current table state and update it to the new table schema, and a "downgrade" method that should take the upgraded table state and turn it back
-into the prior schema. It's recommended to use raw SQL for these migrations, as alembic does not support certain functionality (i.e cascade deletes)
-well.
+This will generate a new file called something like "abcdef123456_descriptive_message_here.py". It will contain an "upgrade" method should take the current table state and update it to the new table schema, and a "downgrade" method that should take the upgraded table state and turn it back into the prior schema well. It's recommended to use the sqlalchemy ORM to create the tables, however if you need to drop a table it's reccommended to use raw SQL since SQLAlchemy does not support `CASCADE` well.
 
 For more information on creating and managing migrations, [read the docs](https://alembic.sqlalchemy.org/en/latest/tutorial.html#create-a-migration-script)

--- a/backend/alembic/README.md
+++ b/backend/alembic/README.md
@@ -28,6 +28,6 @@ Migrations should be created on all database changes using
 alembic revision -m "descriptive message here"
 ```
 
-This will generate a new file called something like "abcdef123456_descriptive_message_here.py". It will contain an "upgrade" method should take the current table state and update it to the new table schema, and a "downgrade" method that should take the upgraded table state and turn it back into the prior schema well. It's recommended to use the sqlalchemy ORM to create the tables, however if you need to drop a table it's reccommended to use raw SQL since SQLAlchemy does not support `CASCADE` well.
+This will generate a new file called something like "abcdef123456_descriptive_message_here.py". It will contain an "upgrade" method should take the current table state and update it to the new table schema, and a "downgrade" method that should take the upgraded table state and turn it back into the prior schema well. It's recommended to use the sqlalchemy ORM to create the tables, however if you need to drop a table it's reccommended to use raw SQL, as that will allow you to specify `DROP TABLE CASCADE` where SQLAlchemy's `drop_table` would not. This would result in situations where ex. dropping the `stops` table would fail since it would not cascade to `route_stops`.
 
 For more information on creating and managing migrations, [read the docs](https://alembic.sqlalchemy.org/en/latest/tutorial.html#create-a-migration-script)

--- a/backend/alembic/versions/174e5a759f2d_create_stops_table.py
+++ b/backend/alembic/versions/174e5a759f2d_create_stops_table.py
@@ -7,6 +7,7 @@ Create Date: 2023-10-04 17:25:22.810006
 """
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -17,18 +18,15 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS public.stops (
-	        id serial PRIMARY KEY,
-	        name varchar(255) NOT NULL,
-	        lat float8 NOT NULL,
-	        lon float8 NOT NULL,
-	        active bool NOT NULL,
-	        UNIQUE (name),
-	        UNIQUE (lat, lon)
-        );
-    """
+    op.create_table(
+        "stops",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("lat", sa.Float, nullable=False),
+        sa.Column("lon", sa.Float, nullable=False),
+        sa.Column("active", sa.Boolean, nullable=False),
+        sa.UniqueConstraint("name"),
+        sa.UniqueConstraint("lat", "lon"),
     )
 
 

--- a/backend/alembic/versions/1a8780dd5bbc_add_route_color.py
+++ b/backend/alembic/versions/1a8780dd5bbc_add_route_color.py
@@ -1,0 +1,35 @@
+"""add route color
+
+Revision ID: 1a8780dd5bbc
+Revises: c3c081cb6ba8
+Create Date: 2024-01-18 14:05:37.390091
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.schema import CheckConstraint
+
+# revision identifiers, used by Alembic.
+revision: str = "1a8780dd5bbc"
+down_revision: Union[str, None] = "c3c081cb6ba8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "routes",
+        sa.Column(
+            "color",
+            sa.String(),
+            nullable=False,
+            server_default="#000000",
+            *CheckConstraint("color ~* '^#([A-Fa-f0-9]{6})$')")
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("routes", "color")

--- a/backend/alembic/versions/233206860d70_create_waypoints_table.py
+++ b/backend/alembic/versions/233206860d70_create_waypoints_table.py
@@ -7,6 +7,7 @@ Create Date: 2023-10-04 17:35:37.020567
 """
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -17,19 +18,18 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS public.waypoints (
-	        id serial PRIMARY KEY,
-	        route_id int NOT NULL,
-	        lat float8 NOT NULL,
-	        lon float8 NOT NULL,
-	        UNIQUE (route_id, lat, lon),
-	        FOREIGN KEY (route_id)
-		        REFERENCES routes (id)
-                ON DELETE CASCADE
-        );
-    """
+    op.create_table(
+        "waypoints",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "route_id",
+            sa.Integer,
+            sa.ForeignKey("routes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("lat", sa.Float, nullable=False),
+        sa.Column("lon", sa.Float, nullable=False),
+        sa.UniqueConstraint("route_id", "lat", "lon"),
     )
 
 

--- a/backend/alembic/versions/311f80f8b8dd_create_routes_table.py
+++ b/backend/alembic/versions/311f80f8b8dd_create_routes_table.py
@@ -7,6 +7,7 @@ Create Date: 2023-10-04 17:32:02.895752
 """
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -17,14 +18,11 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS public.routes (
-	        id serial PRIMARY KEY,
-	        name varchar(255) NOT NULL,
-	        UNIQUE (name)
-        );
-    """
+    op.create_table(
+        "routes",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.UniqueConstraint("name"),
     )
 
 

--- a/backend/alembic/versions/3e3261e602b0_create_route_stops_table.py
+++ b/backend/alembic/versions/3e3261e602b0_create_route_stops_table.py
@@ -7,6 +7,7 @@ Create Date: 2023-10-04 17:40:15.926603
 """
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -17,22 +18,23 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS public.route_stops (
-	        id serial PRIMARY KEY,
-	        route_id int NOT NULL,
-	        stop_id int NOT NULL,
-            position int NOT NULL,
-	        UNIQUE (route_id, stop_id),
-	        FOREIGN KEY (route_id)
-		        REFERENCES routes (id)
-		        ON DELETE CASCADE,
-	        FOREIGN KEY (stop_id)
-		        REFERENCES stops (id)
-		        ON DELETE CASCADE
-        );
-    """
+    op.create_table(
+        "route_stops",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "route_id",
+            sa.Integer,
+            sa.ForeignKey("routes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "stop_id",
+            sa.Integer,
+            sa.ForeignKey("stops.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("position", sa.Integer, nullable=False),
+        sa.UniqueConstraint("route_id", "stop_id"),
     )
 
 

--- a/backend/alembic/versions/87f033493d8b_create_schedules_table.py
+++ b/backend/alembic/versions/87f033493d8b_create_schedules_table.py
@@ -7,6 +7,7 @@ Create Date: 2023-10-04 17:35:29.449383
 """
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -17,20 +18,25 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS public.schedules (
-	        id serial PRIMARY KEY,
-	        route_id int NOT NULL,
-	        dow int NOT NULL CHECK (dow >= 0 AND dow <= 6), -- Sunday is 0 (https://www.postgresql.org/docs/8.1/functions-datetime.html)
-	        start_time timetz NOT NULL,
-	        end_time timetz NOT NULL CHECK (end_time > start_time),
-	        UNIQUE (route_id, dow),
-	        FOREIGN KEY (route_id)
-		        REFERENCES routes (id)
-		        ON DELETE CASCADE
-        );
-    """
+    op.create_table(
+        "schedules",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "route_id",
+            sa.Integer,
+            sa.ForeignKey("routes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "dow",
+            sa.Integer,
+            nullable=False,
+            server_default="0",
+            check=(sa.text("dow >= 0 AND dow <= 6")),
+        ),
+        sa.Column("start_time", sa.Time(timezone=False), nullable=False),
+        sa.Column("end_time", sa.Time(timezone=False), nullable=False),
+        sa.UniqueConstraint("route_id", "dow"),
     )
 
 

--- a/backend/alembic/versions/87f033493d8b_create_schedules_table.py
+++ b/backend/alembic/versions/87f033493d8b_create_schedules_table.py
@@ -32,11 +32,12 @@ def upgrade() -> None:
             sa.Integer,
             nullable=False,
             server_default="0",
-            check=(sa.text("dow >= 0 AND dow <= 6")),
         ),
         sa.Column("start_time", sa.Time(timezone=False), nullable=False),
         sa.Column("end_time", sa.Time(timezone=False), nullable=False),
         sa.UniqueConstraint("route_id", "dow"),
+        sa.CheckConstraint("dow >= 0 AND dow <= 6"),
+        sa.CheckConstraint("end_time > start_time"),
     )
 
 

--- a/backend/alembic/versions/b8ce06a37505_create_ridership_table.py
+++ b/backend/alembic/versions/b8ce06a37505_create_ridership_table.py
@@ -7,6 +7,7 @@ Create Date: 2023-10-04 17:40:44.364879
 """
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -17,32 +18,25 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS public.ridership (
-	        id serial PRIMARY KEY,
-	        van_id int NOT NULL,
-	        route_id int NOT NULL,
-	        entered int NOT NULL,
-	        exited int NOT NULL,
-	        lat float8 NOT NULL,
-	        lon float8 NOT NULL,
-	        datetime timestamptz NOT NULL,
-	        UNIQUE (van_id, datetime),
-	        FOREIGN KEY (van_id)
-		        REFERENCES vans (id)
-		        ON DELETE CASCADE,
-	        FOREIGN KEY (route_id)
-		        REFERENCES routes (id)
-		        ON DELETE CASCADE
-        );
-    """
+    op.create_table(
+        "ridership",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("van_id", sa.Integer, nullable=False),
+        sa.Column("route_id", sa.Integer, nullable=False),
+        sa.Column("entered", sa.Integer, nullable=False),
+        sa.Column("exited", sa.Integer, nullable=False),
+        sa.Column("lat", sa.Float, nullable=False),
+        sa.Column("lon", sa.Float, nullable=False),
+        sa.Column("datetime", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("van_id", "datetime"),
+        sa.ForeignKeyConstraint(["van_id"], ["vans.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["route_id"], ["routes.id"], ondelete="CASCADE"),
     )
 
 
 def downgrade() -> None:
     op.execute(
         """
-        DROP TABLE IF EXISTS public.ridership;
-    """
+		DROP TABLE IF EXISTS public.ridership;
+	"""
     )

--- a/backend/alembic/versions/b8ce06a37505_create_ridership_table.py
+++ b/backend/alembic/versions/b8ce06a37505_create_ridership_table.py
@@ -21,16 +21,24 @@ def upgrade() -> None:
     op.create_table(
         "ridership",
         sa.Column("id", sa.Integer, primary_key=True),
-        sa.Column("van_id", sa.Integer, nullable=False),
-        sa.Column("route_id", sa.Integer, nullable=False),
+        sa.Column(
+            "van_id",
+            sa.Integer,
+            sa.ForeignKey("vans.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "route_id",
+            sa.Integer,
+            sa.ForeignKey("routes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
         sa.Column("entered", sa.Integer, nullable=False),
         sa.Column("exited", sa.Integer, nullable=False),
         sa.Column("lat", sa.Float, nullable=False),
         sa.Column("lon", sa.Float, nullable=False),
         sa.Column("datetime", sa.DateTime(timezone=True), nullable=False),
         sa.UniqueConstraint("van_id", "datetime"),
-        sa.ForeignKeyConstraint(["van_id"], ["vans.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["route_id"], ["routes.id"], ondelete="CASCADE"),
     )
 
 

--- a/backend/alembic/versions/c3c081cb6ba8_create_stop_disables_table.py
+++ b/backend/alembic/versions/c3c081cb6ba8_create_stop_disables_table.py
@@ -7,6 +7,7 @@ Create Date: 2023-10-05 13:24:21.692774
 """
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -17,20 +18,21 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS public.stop_disables (
-	        id serial PRIMARY KEY,
-	        alert_id int NOT NULL,
-	        stop_id int NOT NULL,
-	        FOREIGN KEY (alert_id)
-		        REFERENCES alerts (id)
-		        ON DELETE CASCADE,
-	        FOREIGN KEY (stop_id)
-		        REFERENCES stops (id)
-		        ON DELETE CASCADE
-        );
-    """
+    op.create_table(
+        "stop_disables",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "alert_id",
+            sa.Integer,
+            sa.ForeignKey("alerts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "stop_id",
+            sa.Integer,
+            sa.ForeignKey("stops.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
     )
 
 

--- a/backend/alembic/versions/dc6fb3eee9e3_create_alerts_table.py
+++ b/backend/alembic/versions/dc6fb3eee9e3_create_alerts_table.py
@@ -7,6 +7,7 @@ Create Date: 2023-10-04 17:24:21.822457
 """
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -17,15 +18,18 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS public.alerts (
-	        id serial PRIMARY KEY,
-	        text VARCHAR(500) NOT NULL,
-	        start_datetime timestamptz NOT NULL,
-	        end_datetime timestamptz NOT NULL CHECK (end_datetime > start_datetime)
-        );
-    """
+    op.create_table(
+        "alerts",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("text", sa.String(500), nullable=False),
+        sa.Column("start_datetime", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column(
+            "end_datetime",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("(now() at time zone 'utc')"),
+        ),
+        sa.CheckConstraint("end_datetime > start_datetime"),
     )
 
 

--- a/backend/alembic/versions/e74cdc7a92b6_create_route_disables_table.py
+++ b/backend/alembic/versions/e74cdc7a92b6_create_route_disables_table.py
@@ -7,6 +7,7 @@ Create Date: 2023-10-04 17:40:30.795226
 """
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -17,20 +18,21 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS public.route_disables (
-	        id serial PRIMARY KEY,
-	        alert_id int NOT NULL,
-	        route_id int NOT NULL,
-	        FOREIGN KEY (alert_id)
-		        REFERENCES alerts (id)
-		        ON DELETE CASCADE,
-	        FOREIGN KEY (route_id)
-		        REFERENCES routes (id)
-		        ON DELETE CASCADE
-        );
-    """
+    op.create_table(
+        "route_disables",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "alert_id",
+            sa.Integer,
+            sa.ForeignKey("alerts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "route_id",
+            sa.Integer,
+            sa.ForeignKey("routes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
     )
 
 

--- a/backend/alembic/versions/f1a02e4febad_create_vans_table.py
+++ b/backend/alembic/versions/f1a02e4febad_create_vans_table.py
@@ -7,6 +7,7 @@ Create Date: 2023-10-04 17:31:57.484449
 """
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -17,17 +18,12 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS public.vans (
-	        id serial PRIMARY KEY,
-	        route_id int,
-	        wheelchair bool NOT NULL,
-	        FOREIGN KEY (route_id)
-		        REFERENCES routes (id)
-		        ON DELETE SET NULL
-        );
-    """
+    op.create_table(
+        "vans",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("route_id", sa.Integer),
+        sa.Column("wheelchair", sa.Boolean, nullable=False),
+        sa.ForeignKeyConstraint(["route_id"], ["routes.id"], ondelete="SET NULL"),
     )
 
 

--- a/backend/alembic/versions/f1a02e4febad_create_vans_table.py
+++ b/backend/alembic/versions/f1a02e4febad_create_vans_table.py
@@ -21,9 +21,8 @@ def upgrade() -> None:
     op.create_table(
         "vans",
         sa.Column("id", sa.Integer, primary_key=True),
-        sa.Column("route_id", sa.Integer),
+        sa.Column("route_id", sa.Integer, sa.ForeignKey("routes.id"), nullable=True),
         sa.Column("wheelchair", sa.Boolean, nullable=False),
-        sa.ForeignKeyConstraint(["route_id"], ["routes.id"], ondelete="SET NULL"),
     )
 
 

--- a/backend/src/model/route.py
+++ b/backend/src/model/route.py
@@ -1,4 +1,4 @@
-from sqlalchemy import UniqueConstraint
+from sqlalchemy import String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from src.db import Base
 from src.model.waypoint import Waypoint  # pylint: disable=unused-import
@@ -6,17 +6,27 @@ from src.model.waypoint import Waypoint  # pylint: disable=unused-import
 
 class Route(Base):
     __tablename__ = "routes"
-    __table_args__ = (UniqueConstraint("name"),)
+    # Note: DO NOT add the check constraint to this model, it's used in Postgres
+    # and SQLite, but SQLite doesn't support check constraints w/regex.
+    __table_args__ = (UniqueConstraint("name"),)  # type: ignore
     id: Mapped[int] = mapped_column(
         primary_key=True, autoincrement=True, nullable=False
     )
     name: Mapped[str] = mapped_column(unique=True, nullable=False)
+    color: Mapped[str] = mapped_column(
+        String(7),
+        nullable=True,
+    )
 
     waypoints = relationship("Waypoint", backref="route", cascade="all, delete-orphan")
 
     def __eq__(self, __value: object) -> bool:
         # Exclude ID since it'll always differ, only compare on content
-        return isinstance(__value, Route) and self.name == __value.name
+        return (
+            isinstance(__value, Route)
+            and self.name == __value.name
+            and self.color == __value.color
+        )
 
     def __repr__(self) -> str:
-        return f"<Route id={self.id} name={self.name}>"
+        return f"<Route id={self.id} name={self.name} color={self.color}>"

--- a/backend/tests/test_stops.py
+++ b/backend/tests/test_stops.py
@@ -51,8 +51,8 @@ def mock_stops():
 @pytest.fixture
 def mock_routes():
     return [
-        Route(id=1, name="Route 1"),
-        Route(id=2, name="Route 2"),
+        Route(id=1, name="Route 1", color="#000000"),
+        Route(id=2, name="Route 2", color="#000000"),
     ]
 
 


### PR DESCRIPTION
EXCEPT when downgrading, as we need to cascade drop and sqlalchemy does not support doing that for some reason