### PR TITLE
Backend: Make KML polygons hold ordered stops

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ annotated-types==0.5.0
 anyio==3.7.1
 astroid==2.15.8
 black==23.9.1
+beautifulsoup4==4.10.0
 cachetools==5.3.2
 click==8.1.7
 dill==0.3.7

--- a/backend/src/handlers/routes.py
+++ b/backend/src/handlers/routes.py
@@ -103,7 +103,22 @@ def get_kml(req: Request):
         style.append_style(PolyStyle(fill=0))  # No fill
 
         for route in routes:
-            p = kml.Placemark(ns, route.name, route.name, route.name)
+            stop_ids = [
+                route_stop.stop_id
+                for route_stop in route_stops
+                if route_stop.route_id == route.id
+            ]
+            stop_divs = "".join(
+                [
+                    f"<div>{route.name}<br></div>"
+                    for route in routes
+                    if route.id in stop_ids
+                ]
+            )
+
+            description = f"<![CDATA[{stop_divs}]]>"
+
+            p = kml.Placemark(ns, route.name, route.name, route.name, description)
             p.geometry = Polygon([(w.lon, w.lat, 0) for w in route.waypoints])
 
             p.append_style(style)
@@ -112,22 +127,7 @@ def get_kml(req: Request):
             d.append(p)
 
         for stop in stops:
-            route_ids = [
-                route_stop.route_id
-                for route_stop in route_stops
-                if route_stop.stop_id == stop.id
-            ]
-            routes_divs = "".join(
-                [
-                    f"<div>{route.name}<br></div>"
-                    for route in routes
-                    if route.id in route_ids
-                ]
-            )
-
-            description = f"<![CDATA[{routes_divs}]]>"
-
-            p = kml.Placemark(ns, stop.name, stop.name, description)
+            p = kml.Placemark(ns, stop.name, stop.name)
             p.geometry = Point(stop.lon, stop.lat)
             d.append(p)
 

--- a/backend/src/handlers/routes.py
+++ b/backend/src/handlers/routes.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import Annotated, Optional
 
 import pygeoif
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup  # type: ignore
 from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import JSONResponse
 from fastkml import kml


### PR DESCRIPTION
Instead of making stops reference their routes, instead make route polygons reference stop placemarks.

This allows stops to be properly ordered in the direction vans visit them easily.