### PR TITLE
Add route description

### DIFF
--- a/backend/alembic/versions/4183de971218_add_route_description.py
+++ b/backend/alembic/versions/4183de971218_add_route_description.py
@@ -1,0 +1,29 @@
+"""add route description
+
+Revision ID: 4183de971218
+Revises: 8166e12f260c
+Create Date: 2024-03-24 12:31:02.141874
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4183de971218"
+down_revision: Union[str, None] = "8166e12f260c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "routes",
+        sa.Column("description", sa.String(255), nullable=False, server_default=""),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("routes", "description")

--- a/backend/src/handlers/routes.py
+++ b/backend/src/handlers/routes.py
@@ -352,7 +352,20 @@ async def create_route(req: Request, kml_file: UploadFile):
                 if isinstance(style, PolyStyle):
                     color = style.color
                     break
-            route_model = Route(name=route_name, color=color)
+            # Want the text contents of all of the surface-level divs and then strip
+            # all of the tags of it's content
+
+            route_desc_html = BeautifulSoup(route.description, features="html.parser")
+            entries = [
+                div.text.strip()
+                for div in route_desc_html.find_all("div", recursive=False)
+            ]
+
+            if len(entries) < 3:
+                return HTTPException(status_code=400, detail="bad kml file")
+
+            description = entries[0]
+            route_model = Route(name=route_name, color=color, description=description)
             session.add(route_model)
             session.flush()
 
@@ -371,17 +384,7 @@ async def create_route(req: Request, kml_file: UploadFile):
                 session.add(waypoint)
                 session.flush()
 
-            route_desc_html = BeautifulSoup(route.description, features="html.parser")
-
-            # Want the text contents of all of the surface-level divs and then strip
-            # all of the tags of it's content
-
-            route_stops = [
-                div.text.strip()
-                for div in route_desc_html.find_all("div", recursive=False)
-            ]
-
-            for pos, stop in enumerate(route_stops):
+            for pos, stop in enumerate(entries[1:]):
                 if stop not in stop_id_map:
                     continue
                 stop_id = stop_id_map[stop]

--- a/backend/src/handlers/routes.py
+++ b/backend/src/handlers/routes.py
@@ -34,6 +34,7 @@ FIELD_WAYPOINTS = "waypoints"
 FIELD_IS_ACTIVE = "isActive"
 FIELD_LATITUDE = "latitude"
 FIELD_LONGITUDE = "longitude"
+FIELD_DESCRIPTION = "description"
 INCLUDES = {
     FIELD_STOP_IDS,
     FIELD_WAYPOINTS,
@@ -64,7 +65,11 @@ def get_routes(
 
         routes_json = []
         for route in routes:
-            route_json = {FIELD_ID: route.id, FIELD_NAME: route.name}
+            route_json = {
+                FIELD_ID: route.id,
+                FIELD_NAME: route.name,
+                FIELD_DESCRIPTION: route.description,
+            }
 
             # Add related values to the route if included
             if FIELD_STOP_IDS in include_set:
@@ -204,7 +209,11 @@ def get_route(
         if not route:
             raise HTTPException(status_code=404, detail="Route not found")
 
-        route_json = {FIELD_ID: route.id, FIELD_NAME: route.name}
+        route_json = {
+            FIELD_ID: route.id,
+            FIELD_NAME: route.name,
+            FIELD_DESCRIPTION: route.description,
+        }
 
         # Add related values to the route if included
         if FIELD_STOP_IDS in include_set:

--- a/backend/src/model/route.py
+++ b/backend/src/model/route.py
@@ -17,6 +17,11 @@ class Route(Base):
         String(7),
         nullable=True,
     )
+    description: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        server_default="",
+    )
 
     waypoints = relationship("Waypoint", backref="route", cascade="all, delete-orphan")
 


### PR DESCRIPTION
Add a route description field to the database and API, rather than hard-coding it into the app. The first line in the route KML polygon is now considered the description, followed by the stops.